### PR TITLE
refactor: Remove header parameter for github authentication token

### DIFF
--- a/src/implementations/fetch_github_issues_with_specific_params.rb
+++ b/src/implementations/fetch_github_issues_with_specific_params.rb
@@ -107,7 +107,6 @@ module Implementation
     def headers
       {
         'User-Agent' => 'RubyBot',
-        'Authorization' => "Bearer #{ENV.fetch('GITHUB_TOKEN')}",
         'Accept' => 'application/vnd.github+json'
       }
     end


### PR DESCRIPTION
## Description

Removed GitHub authorization token argument from parameters (headers) that are sent in the request for querying GitHub issues

Fixes # (issue)


## Type of change
Refactoring

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
