### PR TITLE
Fix OSPO projects fetching schedule

### DIFF
--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -99,27 +99,27 @@ module UseCasesExecution
     ].freeze
 
     OSPO_PROJECT_ISSUES = [
-      { path: "#{__dir__}/ospo_maintenance/projects/bas", time: ['08:00', '11:00', '14:00', '17:00', '20:00'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/bas_use_cases",
+      { path: "#{__dir__}/ospo_maintenance/projects/bas.rb", time: ['08:00', '11:00', '14:00', '17:00', '20:00'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/bas_use_cases.rb",
         time: ['08:01', '11:01', '14:01', '17:01', '20:01'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_dapp", time: ['18:00'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_prototype", time: ['18:01'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_smart_contracts", time: ['18:02'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_break_line", time: ['18:03'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_drag_drop", time: ['18:04'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_inline_image", time: ['18:05'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_toggle_block", time: ['18:06'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_tooltip", time: ['18:07'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/editor_js_undo", time: ['18:08'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/elixir_xdr", time: ['18:09'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/kadena_ex", time: ['18:10'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/mintacoin", time: ['18:11'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/mtk_automation", time: ['18:12'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/soroban_ex", time: ['18:13'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/soroban_smart_contracts", time: ['18:14'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/stellar_base", time: ['18:15'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/stellar_sdk", time: ['18:16'] },
-      { path: "#{__dir__}/ospo_maintenance/projects/tickspot_js", time: ['18:17'] }
+      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_dapp.rb", time: ['18:00'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_prototype.rb", time: ['18:01'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/chaincerts_smart_contracts.rb", time: ['18:02'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_break_line.rb", time: ['18:03'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_drag_drop.rb", time: ['18:04'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_inline_image.rb", time: ['18:05'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_toggle_block.rb", time: ['18:06'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editorjs_tooltip.rb", time: ['18:07'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/editor_js_undo.rb", time: ['18:08'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/elixir_xdr.rb", time: ['18:09'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/kadena_ex.rb", time: ['18:10'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/mintacoin.rb", time: ['18:11'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/mtk_automation.rb", time: ['18:12'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/soroban_ex.rb", time: ['18:13'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/soroban_smart_contracts.rb", time: ['18:14'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/stellar_base.rb", time: ['18:15'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/stellar_sdk.rb", time: ['18:16'] },
+      { path: "#{__dir__}/ospo_maintenance/projects/tickspot_js.rb", time: ['18:17'] }
     ].freeze
 
     EXPIRED_PROJECTS_SCHEDULES = [


### PR DESCRIPTION
## Description

Schedules for `ospo_maintenance/projects` were missing file extensions, preventing execution.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated scheduled script paths to explicitly include the `.rb` file extension. No changes to scheduling times or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->