### PR TITLE
Add WorkLogs migration and service

### DIFF
--- a/db/warehouse_migrations/20250620164412_create_work_logs_table.rb
+++ b/db/warehouse_migrations/20250620164412_create_work_logs_table.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:work_logs) do
+      uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
+      String :external_work_log_id, size: 255, null: false
+      Integer :duration_minutes, null: false
+      column :tags, 'text[]', null: true
+      foreign_key :person_id, :persons, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :set_null
+      foreign_key :activity_id, :activities, type: :uuid, null: true, on_delete: :set_null
+      foreign_key :work_item_id, :work_items, type: :uuid, null: true, on_delete: :set_null
+      DateTime :creation_date, null: false
+      DateTime :modification_date, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
+  down do
+    drop_table(:work_logs)
+  end
+end

--- a/db/warehouse_migrations/20250620164412_create_work_logs_table.rb
+++ b/db/warehouse_migrations/20250620164412_create_work_logs_table.rb
@@ -8,11 +8,15 @@ Sequel.migration do
       Integer :duration_minutes, null: false
       column :tags, 'text[]', null: true
       foreign_key :person_id, :persons, type: :uuid, null: false, on_delete: :cascade
-      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :set_null
-      foreign_key :activity_id, :activities, type: :uuid, null: true, on_delete: :set_null
-      foreign_key :work_item_id, :work_items, type: :uuid, null: true, on_delete: :set_null
+      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :activity_id, :activities, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :work_item_id, :work_items, type: :uuid, null: true, on_delete: :cascade
       DateTime :creation_date, null: false
       DateTime :modification_date, null: true
+      Boolean :external, null: true
+      Boolean :deleted, null: true
+      DateTime :started_at, null: false
+      String :description, null: true
       DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end

--- a/spec/services/postgres/activities_key_results_spec.rb
+++ b/spec/services/postgres/activities_key_results_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Services::Postgres::ActivitiesKeyResults do
     db.drop_table?(:activities_key_results)
     db.drop_table?(:key_results)
     db.drop_table?(:activities)
+    db.drop_table?(:domains)
 
+    create_domains_table(db)
     create_key_results_table(db)
     create_activities_table(db)
     create_activities_key_results_table(db)

--- a/spec/services/postgres/milestone_spec.rb
+++ b/spec/services/postgres/milestone_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Services::Postgres::Milestone do
   before(:each) do
     db.drop_table?(:milestones)
     db.drop_table?(:projects)
+    db.drop_table?(:domains)
 
     create_domains_table(db)
     create_milestones_table(db)

--- a/spec/services/postgres/milestone_spec.rb
+++ b/spec/services/postgres/milestone_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Services::Postgres::Milestone do
     db.drop_table?(:milestones)
     db.drop_table?(:projects)
 
+    create_domains_table(db)
     create_milestones_table(db)
     create_projects_table(db)
 

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'securerandom'
 module TestDBHelpers # rubocop:disable Metrics/ModuleLength
   def create_projects_table(db)
     db.create_table(:projects) do
@@ -7,9 +8,9 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :external_project_id, null: false
       String :name, null: false
       String :status, null: false
-      Integer :domain_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -18,9 +19,9 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       primary_key :id
       String :external_activity_id, null: false
       String :name, null: false
-      Integer :domain_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -30,8 +31,8 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :external_domain_id, null: false
       String :name, null: false
       Boolean :archived, default: false, null: false
-      DateTime :created_at
-      DateTime :updated_at
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -48,9 +49,9 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :github_username, null: true
       Integer :notion_user_id, null: true
       Integer :worklogs_user_id, null: true
-      Integer :domain_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -61,13 +62,13 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :name, null: false
       String :status, null: false
       DateTime :completion_date
-      Integer :project_id
-      Integer :activity_id
-      Integer :domain_id
-      Integer :person_id
-      Integer :weekly_scope_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :activity_id, :activities, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :weekly_scope_id, :weekly_scopes, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -78,9 +79,9 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :name, null: false
       String :status, null: false
       DateTime :completion_date
-      Integer :project_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -89,23 +90,23 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       primary_key :id
       String :name, null: false
       String :external_document_id, null: false
-      Integer :domain_id
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
-  def create_weekly_scope_table(db) # rubocop:disable Metrics/MethodLength
+  def create_weekly_scopes_table(db) # rubocop:disable Metrics/MethodLength
     db.create_table(:weekly_scopes) do
       primary_key :id
       String :external_weekly_scope_id, null: false
       String :description, null: false
-      Integer :domain_id
-      Integer :person_id
+      foreign_key :domain_id, :domains, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :cascade
       DateTime :start_week_date
       DateTime :end_week_date
-      DateTime :created_at
-      DateTime :updated_at
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -120,8 +121,8 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       Float :progress, null: false
       String :period, null: false
       String :objective, null: false
-      DateTime :created_at
-      DateTime :updated_at
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
@@ -137,35 +138,39 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       Float :progress, null: false
       String :period, null: false
       String :objective, null: false
-      DateTime :created_at
-      DateTime :updated_at
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
   def create_activities_key_results_table(db)
     db.create_table(:activities_key_results) do
       primary_key :id
-      foreign_key :activity_id, :activities, on_delete: :cascade
-      foreign_key :key_result_id, :key_results, on_delete: :cascade
-      DateTime :created_at
-      DateTime :updated_at
+      foreign_key :activity_id, :activities, type: :uuid, on_delete: :cascade
+      foreign_key :key_result_id, :key_results, type: :uuid, on_delete: :cascade
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 
-  def create_work_logs_table(db) # rubocop:disable Metrics/MethodLength
+  def create_work_logs_table(db) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
     db.create_table :work_logs do
       primary_key :id
       String :external_work_log_id, size: 255, null: false
       Integer :duration_minutes, null: false
-      Text :tags
-      foreign_key :person_id, :persons, null: false, on_delete: :cascade
-      foreign_key :project_id, :projects, null: true, on_delete: :set_null
-      foreign_key :activity_id, :activities, null: true, on_delete: :set_null
-      foreign_key :work_item_id, :work_items, null: true, on_delete: :set_null
+      column :tags, 'text[]', null: true
+      foreign_key :person_id, :persons, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :project_id, :projects, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :activity_id, :activities, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :work_item_id, :work_items, type: :uuid, null: true, on_delete: :cascade
       DateTime :creation_date, null: false
-      DateTime :modification_date
-      DateTime :created_at
-      DateTime :updated_at
+      DateTime :modification_date, null: true
+      TrueClass :external, null: true
+      TrueClass :deleted, null: true
+      DateTime :started_at, null: false
+      String :description, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
 end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -151,4 +151,21 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       DateTime :updated_at
     end
   end
+
+  def create_work_logs_table(db) # rubocop:disable Metrics/MethodLength
+    db.create_table :work_logs do
+      primary_key :id
+      String :external_work_log_id, size: 255, null: false
+      Integer :duration_minutes, null: false
+      Text :tags
+      foreign_key :person_id, :persons, null: false, on_delete: :cascade
+      foreign_key :project_id, :projects, null: true, on_delete: :set_null
+      foreign_key :activity_id, :activities, null: true, on_delete: :set_null
+      foreign_key :work_item_id, :work_items, null: true, on_delete: :set_null
+      DateTime :creation_date, null: false
+      DateTime :modification_date
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
 end

--- a/spec/services/postgres/weekly_scope_spec.rb
+++ b/spec/services/postgres/weekly_scope_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Services::Postgres::WeeklyScope do
 
     create_domains_table(db)
     create_persons_table(db)
-    create_weekly_scope_table(db)
+    create_weekly_scopes_table(db)
 
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end

--- a/spec/services/postgres/work_item_spec.rb
+++ b/spec/services/postgres/work_item_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Services::Postgres::WorkItem do
     create_domains_table(db)
     create_persons_table(db)
     create_work_items_table(db)
-    create_weekly_scope_table(db)
+    create_weekly_scopes_table(db)
 
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end

--- a/spec/services/postgres/work_log_spec.rb
+++ b/spec/services/postgres/work_log_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe Services::Postgres::WorkLog do
   end
 
   describe '#delete' do
-    it 'removes a work_log' do
-      person_id = person_service.insert(external_person_id: 'person-5', full_name: 'Deleter')
+    it 'deletes a work_log' do
+      person_id = person_service.insert(external_person_id: 'person-5', full_name: 'Deleted')
       id = service.insert(
         external_work_log_id: 'ext-log-5',
         duration_minutes: 30,

--- a/spec/services/postgres/work_log_spec.rb
+++ b/spec/services/postgres/work_log_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Services::Postgres::WorkLog do
     db.drop_table?(:domains)
     db.drop_table?(:persons)
     db.drop_table?(:work_items)
+    db.drop_table?(:weekly_scopes)
 
     create_projects_table(db)
     create_activities_table(db)
@@ -38,6 +39,7 @@ RSpec.describe Services::Postgres::WorkLog do
     create_persons_table(db)
     create_work_items_table(db)
     create_work_logs_table(db)
+    create_weekly_scopes_table(db)
 
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end
@@ -49,7 +51,8 @@ RSpec.describe Services::Postgres::WorkLog do
         external_work_log_id: 'ext-log-1',
         duration_minutes: 90,
         creation_date: Time.now,
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       }
       id = service.insert(params)
       log = service.find(id)
@@ -69,7 +72,8 @@ RSpec.describe Services::Postgres::WorkLog do
         external_person_id: 'person-2',
         external_project_id: 'proj-1',
         external_activity_id: 'act-1',
-        external_work_item_id: 'wi-1'
+        external_work_item_id: 'wi-1',
+        started_at: Time.now
       }
       id = service.insert(params)
       log = service.find(id)
@@ -86,7 +90,8 @@ RSpec.describe Services::Postgres::WorkLog do
         duration_minutes: 120,
         creation_date: Time.now,
         tags: JSON.generate(%w[urgent backend]),
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       }
       id = service.insert(params)
       log = service.find(id)
@@ -102,7 +107,8 @@ RSpec.describe Services::Postgres::WorkLog do
         duration_minutes: 45,
         creation_date: Time.now,
         tags: JSON.generate(%w[init]),
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       )
       service.update(id, duration_minutes: 75, tags: JSON.generate(%w[revised important]))
       log = service.find(id)
@@ -118,7 +124,8 @@ RSpec.describe Services::Postgres::WorkLog do
         external_work_log_id: 'ext-log-5',
         duration_minutes: 30,
         creation_date: Time.now,
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       )
       expect { service.delete(id) }.to change { service.query.size }.by(-1)
     end
@@ -131,7 +138,8 @@ RSpec.describe Services::Postgres::WorkLog do
         external_work_log_id: 'ext-log-6',
         duration_minutes: 100,
         creation_date: Time.now,
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       )
       log = service.find(id)
       expect(log[:external_work_log_id]).to eq('ext-log-6')
@@ -145,7 +153,8 @@ RSpec.describe Services::Postgres::WorkLog do
         external_work_log_id: 'ext-log-7',
         duration_minutes: 20,
         creation_date: Time.now,
-        person_id: person_id
+        person_id: person_id,
+        started_at: Time.now
       )
       results = service.query(duration_minutes: 20)
       expect(results.size).to be >= 1

--- a/spec/services/postgres/work_log_spec.rb
+++ b/spec/services/postgres/work_log_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'rspec'
+require_relative '../../../src/services/postgres/base'
+require_relative '../../../src/services/postgres/work_log'
+require_relative '../../../src/services/postgres/project'
+require_relative '../../../src/services/postgres/activity'
+require_relative '../../../src/services/postgres/domain'
+require_relative '../../../src/services/postgres/person'
+require_relative '../../../src/services/postgres/work_item'
+require_relative 'test_db_helpers'
+require 'json'
+
+RSpec.describe Services::Postgres::WorkLog do
+  include TestDBHelpers
+
+  let(:db) { Sequel.sqlite }
+  let(:config) { { adapter: 'sqlite', database: ':memory:' } }
+  let(:service) { described_class.new(config) }
+  let(:project_service) { Services::Postgres::Project.new(config) }
+  let(:activity_service) { Services::Postgres::Activity.new(config) }
+  let(:domain_service) { Services::Postgres::Domain.new(config) }
+  let(:person_service) { Services::Postgres::Person.new(config) }
+  let(:work_item_service) { Services::Postgres::WorkItem.new(config) }
+
+  before(:each) do
+    db.drop_table?(:work_logs)
+    db.drop_table?(:projects)
+    db.drop_table?(:activities)
+    db.drop_table?(:domains)
+    db.drop_table?(:persons)
+    db.drop_table?(:work_items)
+
+    create_projects_table(db)
+    create_activities_table(db)
+    create_domains_table(db)
+    create_persons_table(db)
+    create_work_items_table(db)
+    create_work_logs_table(db)
+
+    allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
+  end
+
+  describe '#insert' do
+    it 'creates a new work_log and returns its ID' do
+      person_id = person_service.insert(external_person_id: 'person-1', full_name: 'John Doe')
+      params = {
+        external_work_log_id: 'ext-log-1',
+        duration_minutes: 90,
+        creation_date: Time.now,
+        person_id: person_id
+      }
+      id = service.insert(params)
+      log = service.find(id)
+      expect(log[:external_work_log_id]).to eq('ext-log-1')
+      expect(log[:duration_minutes]).to eq(90)
+    end
+
+    it 'assigns foreign keys using external ids' do
+      person_id = person_service.insert(external_person_id: 'person-2', full_name: 'Jane')
+      project_id = project_service.insert(external_project_id: 'proj-1', name: 'Project A', status: 'active')
+      activity_id = activity_service.insert(external_activity_id: 'act-1', name: 'Analysis')
+      work_item_id = work_item_service.insert(external_work_item_id: 'wi-1', name: 'Item A', status: 'todo')
+      params = {
+        external_work_log_id: 'ext-log-2',
+        duration_minutes: 60,
+        creation_date: Time.now,
+        external_person_id: 'person-2',
+        external_project_id: 'proj-1',
+        external_activity_id: 'act-1',
+        external_work_item_id: 'wi-1'
+      }
+      id = service.insert(params)
+      log = service.find(id)
+      expect(log[:person_id]).to eq(person_id)
+      expect(log[:project_id]).to eq(project_id)
+      expect(log[:activity_id]).to eq(activity_id)
+      expect(log[:work_item_id]).to eq(work_item_id)
+    end
+
+    it 'accepts optional tags' do
+      person_id = person_service.insert(external_person_id: 'person-3', full_name: 'With Tags')
+      params = {
+        external_work_log_id: 'ext-log-3',
+        duration_minutes: 120,
+        creation_date: Time.now,
+        tags: JSON.generate(%w[urgent backend]),
+        person_id: person_id
+      }
+      id = service.insert(params)
+      log = service.find(id)
+      expect(log[:tags]).to include('urgent', 'backend')
+    end
+  end
+
+  describe '#update' do
+    it 'updates duration_minutes and tags' do
+      person_id = person_service.insert(external_person_id: 'person-4', full_name: 'Updater')
+      id = service.insert(
+        external_work_log_id: 'ext-log-4',
+        duration_minutes: 45,
+        creation_date: Time.now,
+        tags: JSON.generate(%w[init]),
+        person_id: person_id
+      )
+      service.update(id, duration_minutes: 75, tags: JSON.generate(%w[revised important]))
+      log = service.find(id)
+      expect(log[:duration_minutes]).to eq(75)
+      expect(log[:tags]).to include('revised', 'important')
+    end
+  end
+
+  describe '#delete' do
+    it 'removes a work_log' do
+      person_id = person_service.insert(external_person_id: 'person-5', full_name: 'Deleter')
+      id = service.insert(
+        external_work_log_id: 'ext-log-5',
+        duration_minutes: 30,
+        creation_date: Time.now,
+        person_id: person_id
+      )
+      expect { service.delete(id) }.to change { service.query.size }.by(-1)
+    end
+  end
+
+  describe '#find' do
+    it 'retrieves a work_log by id' do
+      person_id = person_service.insert(external_person_id: 'person-6', full_name: 'Finder')
+      id = service.insert(
+        external_work_log_id: 'ext-log-6',
+        duration_minutes: 100,
+        creation_date: Time.now,
+        person_id: person_id
+      )
+      log = service.find(id)
+      expect(log[:external_work_log_id]).to eq('ext-log-6')
+    end
+  end
+
+  describe '#query' do
+    it 'returns logs with matching duration' do
+      person_id = person_service.insert(external_person_id: 'person-7', full_name: 'Query')
+      service.insert(
+        external_work_log_id: 'ext-log-7',
+        duration_minutes: 20,
+        creation_date: Time.now,
+        person_id: person_id
+      )
+      results = service.query(duration_minutes: 20)
+      expect(results.size).to be >= 1
+    end
+  end
+end

--- a/src/services/postgres/work_log.rb
+++ b/src/services/postgres/work_log.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'person'
+require_relative 'project'
+require_relative 'activity'
+require_relative 'work_item'
+
+module Services
+  module Postgres
+    ##
+    # WorkLog Service for PostgreSQL
+    #
+    # Provides CRUD operations for the 'work_logs' table using the Base service.
+    class WorkLog < Services::Postgres::Base
+      ATTRIBUTES = %i[
+        external_work_log_id duration_minutes tags person_id
+        project_id activity_id work_item_id creation_date modification_date
+      ].freeze
+
+      TABLE = :work_logs
+
+      RELATIONS = [
+        { service: Person, external: :external_person_id, internal: :person_id },
+        { service: Project, external: :external_project_id, internal: :project_id },
+        { service: Activity, external: :external_activity_id, internal: :activity_id },
+        { service: WorkItem, external: :external_work_item_id, internal: :work_item_id }
+      ].freeze
+
+      def insert(params)
+        assign_relations(params)
+
+        transaction do
+          insert_item(TABLE, params)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def update(id, params)
+        raise ArgumentError, 'WorkLog id is required to update' unless id
+
+        assign_relations(params)
+
+        transaction do
+          update_item(TABLE, id, params)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def delete(id)
+        transaction { delete_item(TABLE, id) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def find(id)
+        find_item(TABLE, id)
+      end
+
+      def query(conditions = {})
+        query_item(TABLE, conditions)
+      end
+
+      private
+
+      def handle_error(error)
+        puts "[WorkLog Service ERROR] #{error.class}: #{error.message}"
+        raise error
+      end
+    end
+  end
+end

--- a/src/services/postgres/work_log.rb
+++ b/src/services/postgres/work_log.rb
@@ -16,6 +16,7 @@ module Services
       ATTRIBUTES = %i[
         external_work_log_id duration_minutes tags person_id
         project_id activity_id work_item_id creation_date modification_date
+        external deleted started_at description
       ].freeze
 
       TABLE = :work_logs


### PR DESCRIPTION
## Description

This PR introduces support for managing WorkLogs in the data warehouse. It includes a database migration for the work_logs table and a PostgreSQL service implementing basic CRUD operations using the existing Base service abstraction.

Fixes: #130

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for managing work logs, including creating, updating, deleting, and retrieving entries linked to persons, projects, activities, and work items.
- **Tests**
  - Added comprehensive tests to validate work log operations and data integrity.
- **Chores**
  - Updated test database schema setups for improved consistency, including renaming and adding tables to support domains and weekly scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->