### PR TITLE
Add worklog fetch bot

### DIFF
--- a/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
+++ b/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bas/shared_storage/default'
+require 'bas/shared_storage/postgres'
+require 'ostruct'
+
+# --- Require the actual dependency files ---
+require_relative '../../../../src/implementations/fetch_records_from_work_logs'
+require_relative '../../../../src/utils/warehouse/work_logs/request'
+require_relative '../../../../src/utils/warehouse/work_logs/work_log_formatter'
+
+RSpec.describe Implementation::FetchRecordsFromWorkLogs do
+  let(:options) do
+    {
+      work_logs_url: 'http://fake-api.com',
+      secret: 'fake-secret-123',
+      entity: 'work_log'
+    }
+  end
+
+  let(:shared_storage_reader) { instance_double(Bas::SharedStorage::Default) }
+  let(:shared_storage_writer) { instance_double(Bas::SharedStorage::Postgres) }
+  let(:subject) do
+    described_class.new(options, shared_storage_reader, shared_storage_writer)
+  end
+  let(:formatter) { double('WorkLogFormatter', format: { normalized: true }) }
+
+  before do
+    allow(Utils::Warehouse::WorkLogs::WorkLogFormatter).to receive(:new).and_return(formatter)
+    allow(subject).to receive(:read_response).and_return(OpenStruct.new(inserted_at: '2025-07-01'))
+    allow(Date).to receive(:today).and_return(Date.parse('2025-07-02'))
+  end
+
+  describe '#process' do
+    context 'when API response is successful and has only one page' do
+      let(:api_response) do
+        double('HTTParty::Response',
+               success?: true,
+               parsed_response: {
+                 'logs' => [{ id: 1 }, { id: 2 }]
+               })
+      end
+
+      before do
+        allow(Utils::WorkLogs::Request).to receive(:execute).and_return(api_response)
+      end
+
+      it 'returns a success response with all normalized entities' do
+        result = subject.process
+        expect(result).to have_key(:success)
+        expect(result[:success][:type]).to eq('work_log')
+        expect(result[:success][:content]).to eq([{ normalized: true }, { normalized: true }])
+      end
+    end
+
+    context 'when API response is successful and has multiple pages' do
+      let(:paged_response1) do
+        double('HTTParty::Response',
+               success?: true,
+               parsed_response: { 'logs' => Array.new(100) { { id: 1 } } })
+      end
+      let(:paged_response2) do
+        double('HTTParty::Response',
+               success?: true,
+               parsed_response: { 'logs' => [{ id: 2 }] })
+      end
+
+      before do
+        allow(Utils::WorkLogs::Request).to receive(:execute).and_return(paged_response1, paged_response2)
+      end
+
+      it 'fetches all pages and returns all normalized entities' do
+        result = subject.process
+        expect(result[:success][:content].size).to eq(101)
+      end
+    end
+
+    context 'when API response is an error' do
+      let(:error_response) do
+        double('HTTParty::Response', success?: false, code: 500, message: 'Server Error')
+      end
+
+      before do
+        allow(Utils::WorkLogs::Request).to receive(:execute).and_return(error_response)
+      end
+
+      it 'handles the error gracefully and returns empty content' do
+        result = subject.process
+        expect(result[:success][:content]).to be_empty
+      end
+    end
+  end
+
+  describe '#write' do
+    it 'writes one record per 100 or fewer items in content' do
+      content = Array.new(205) { { normalized: true } }
+      process_response = { success: { type: 'work_log', content: content } }
+      allow(subject).to receive(:process_response).and_return(process_response)
+
+      expect(shared_storage_writer).to receive(:write).exactly(3).times
+
+      subject.write
+    end
+
+    it 'writes nothing if content is empty' do
+      process_response = { success: { type: 'work_log', content: [] } }
+      allow(subject).to receive(:process_response).and_return(process_response)
+      expect(shared_storage_writer).not_to receive(:write)
+      subject.write
+    end
+  end
+end

--- a/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
+++ b/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
@@ -85,9 +85,8 @@ RSpec.describe Implementation::FetchRecordsFromWorkLogs do
         allow(Utils::WorkLogs::Request).to receive(:execute).and_return(error_response)
       end
 
-      it 'handles the error gracefully and returns empty content' do
-        result = subject.process
-        expect(result[:success][:content]).to be_empty
+      it 'raises a runtime error with a specific message' do
+        expect { subject.process }.to raise_error(RuntimeError, 'Error fetching data: 500 - Server Error')
       end
     end
   end

--- a/src/implementations/fetch_records_from_work_logs.rb
+++ b/src/implementations/fetch_records_from_work_logs.rb
@@ -45,7 +45,8 @@ module Implementation
     PAGE_SIZE = 100
 
     def process
-      start_date = read_response.inserted_at || (Date.today - 30).to_s
+      last_sync = read_response
+      start_date = last_sync&.inserted_at || (Date.today - 30).to_s
       end_date = Date.today.to_s
 
       logs = fetch_all_logs(start_date, end_date)

--- a/src/implementations/fetch_records_from_work_logs.rb
+++ b/src/implementations/fetch_records_from_work_logs.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'bas/bot/base'
+require 'date'
+require_relative '../utils/warehouse/work_logs/request'
+require_relative '../utils/warehouse/work_logs/work_log_formatter'
+
+module Implementation
+  ##
+  # Implementation::FetchRecordsFromWorkLogs
+  #
+  # This class implements a bot that fetches records from the WorkLogs API
+  # within a given time range and prepares them to be saved into the data warehouse.
+  #
+  # <b>Usage Example</b>
+  #
+  #   read_options = {
+  #     connection: Config::CONNECTION,
+  #     db_table: 'warehouse_sync',
+  #     avoid_process: true,
+  #     where: 'archived=$1 AND tag=$2 ORDER BY inserted_at DESC',
+  #     params: [false, 'FetchRecordsFromWorkLogs']
+  #   }
+  #
+  #   write_options = {
+  #     connection: Config::CONNECTION,
+  #     db_table: 'warehouse_sync',
+  #     tag: 'FetchRecordsFromWorkLogs'
+  #   }
+  #
+  #   options = {
+  #     work_logs_url: Config::WORK_LOGS_URL,
+  #     secret: Config::WORK_LOGS_API_SECRET,
+  #     entity: 'work_log'
+  #   }
+  #
+  #   shared_storage = Bas::SharedStorage::Postgres.new({ read_options:, write_options: })
+  #
+  #   Implementation::FetchRecordsFromWorkLogs
+  #     .new(options, shared_storage)
+  #     .execute
+  #
+  class FetchRecordsFromWorkLogs < Bas::Bot::Base
+    RECORDS_PER_PAGE = 100
+    PAGE_SIZE = 100
+
+    def process
+      start_date = read_response.inserted_at || (Date.today - 30).to_s
+      end_date = Date.today.to_s
+
+      logs = fetch_all_logs(start_date, end_date)
+
+      normalized_content = normalize_response(Array(logs))
+
+      { success: { type: process_options[:entity], content: normalized_content } }
+    end
+
+    def write
+      content = process_response.dig(:success, :content) || []
+      paged_entities = content.each_slice(PAGE_SIZE).to_a
+
+      paged_entities.each_with_index do |page, idx|
+        record = build_record(
+          content: page, page_index: idx + 1,
+          total_pages: paged_entities.size, total_records: content.size
+        )
+        @shared_storage_writer.write(record)
+      end
+    end
+
+    private
+
+    def fetch_all_logs(start_date, end_date)
+      all_logs = []
+      page = 1
+      loop do
+        response = fetch_page(start_date, end_date, page)
+        break unless response.success? || handle_failed_response(response)
+
+        all_logs.concat(new_logs = Array(response.parsed_response['logs']))
+        break if new_logs.size < RECORDS_PER_PAGE
+
+        page += 1
+      end
+      all_logs
+    end
+
+    def fetch_page(start_date, end_date, page)
+      params = { start_date: start_date, end_date: end_date, page: page }
+      Utils::WorkLogs::Request.execute(
+        token: process_options[:secret],
+        base_url: process_options[:work_logs_url],
+        params: params
+      )
+    end
+
+    def normalize_response(records)
+      records.map { |record| Utils::Warehouse::WorkLogs::WorkLogFormatter.new(record).format }
+    end
+
+    def handle_failed_response(response)
+      puts "Error fetching data: #{response.code} - #{response.message}"
+    end
+
+    def build_record(content:, page_index:, total_pages:, total_records:)
+      {
+        success: {
+          type: process_options[:entity],
+          content: content,
+          page_index: page_index,
+          total_pages: total_pages,
+          total_records: total_records
+        }
+      }
+    end
+  end
+end

--- a/src/implementations/warehouse_ingester.rb
+++ b/src/implementations/warehouse_ingester.rb
@@ -10,6 +10,7 @@ require_relative '../services/postgres/person'
 require_relative '../services/postgres/project'
 require_relative '../services/postgres/weekly_scope'
 require_relative '../services/postgres/work_item'
+require_relative '../services/postgres/work_log'
 
 module Implementation
   ##
@@ -58,7 +59,8 @@ module Implementation
       'person' => { service: Services::Postgres::Person, external_key: 'external_person_id' },
       'project' => { service: Services::Postgres::Project, external_key: 'external_project_id' },
       'weekly_scope' => { service: Services::Postgres::WeeklyScope, external_key: 'external_weekly_scope_id' },
-      'work_item' => { service: Services::Postgres::WorkItem, external_key: 'external_work_item_id' }
+      'work_item' => { service: Services::Postgres::WorkItem, external_key: 'external_work_item_id' },
+      'work_log' => { service: Services::Postgres::WorkLog, external_key: 'external_work_log_id' }
     }.freeze
 
     def process

--- a/src/use_cases_execution/warehouse/notion/warehouse_ingester.rb
+++ b/src/use_cases_execution/warehouse/notion/warehouse_ingester.rb
@@ -19,6 +19,7 @@ array = PG::TextEncoder::Array.new.encode(
     FetchPersonsFromNotionDatabase
     FetchWorkItemsFromNotionDatabase
     FetchMilestonesFromNotionDatabase
+    FetchRecordsFromWorkLogs
   ]
 )
 

--- a/src/use_cases_execution/warehouse/worklogs/config.rb
+++ b/src/use_cases_execution/warehouse/worklogs/config.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+##
+# This file is used to store the configuration of the warehouse sync data.
+# It contains the connection information to the database where the warehouse sync data is stored.
+# The connection information is stored in the CONNECTION constant.
+#
+
+require 'dotenv/load'
+
+module Config
+  CONNECTION = {
+    host: ENV.fetch('DB_HOST'),
+    port: ENV.fetch('DB_PORT'),
+    dbname: ENV.fetch('POSTGRES_DB'),
+    user: ENV.fetch('POSTGRES_USER'),
+    password: ENV.fetch('POSTGRES_PASSWORD')
+  }.freeze
+
+  WAREHOUSE_CONNECTION = {
+    host: ENV.fetch('DB_HOST'),
+    port: ENV.fetch('DB_PORT'),
+    dbname: ENV.fetch('WAREHOUSE_POSTGRES_DB'),
+    user: ENV.fetch('POSTGRES_USER'),
+    password: ENV.fetch('POSTGRES_PASSWORD')
+  }.freeze
+
+  WORK_LOGS_URL = ENV.fetch('WORK_LOGS_URL')
+  WORK_LOGS_API_SECRET = ENV.fetch('WORK_LOGS_API_SECRET')
+end

--- a/src/use_cases_execution/warehouse/worklogs/fetch_work_logs.rb
+++ b/src/use_cases_execution/warehouse/worklogs/fetch_work_logs.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'bas/shared_storage/postgres'
+
+require_relative '../../../implementations/fetch_records_from_work_logs'
+require_relative 'config'
+
+read_options = {
+  connection: Config::CONNECTION,
+  db_table: 'warehouse_sync',
+  avoid_process: true,
+  where: 'archived=$1 AND tag=$2 ORDER BY inserted_at DESC',
+  params: [false, 'FetchRecordsFromWorkLogs']
+}
+
+write_options = {
+  connection: Config::CONNECTION,
+  db_table: 'warehouse_sync',
+  tag: 'FetchRecordsFromWorkLogs'
+}
+
+options = {
+  work_logs_url: Config::WORK_LOGS_URL,
+  secret: Config::WORK_LOGS_API_SECRET,
+  entity: 'work_log'
+}
+
+# Process bot
+begin
+  shared_storage = Bas::SharedStorage::Postgres.new({ read_options:, write_options: })
+
+  Implementation::FetchRecordsFromWorkLogs.new(options, shared_storage).execute
+rescue StandardError => e
+  Logger.new($stdout).info(e.message)
+end

--- a/src/utils/warehouse/work_logs/base.rb
+++ b/src/utils/warehouse/work_logs/base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Utils
+  module Warehouse
+    module WorkLogs
+      ##
+      # Base class for work log utilities.
+      # This class provides methods to handle work log data, such as extracting and formatting.
+      class Base
+        def initialize(work_log_record)
+          @record = work_log_record
+        end
+      end
+    end
+  end
+end

--- a/src/utils/warehouse/work_logs/base.rb
+++ b/src/utils/warehouse/work_logs/base.rb
@@ -10,6 +10,10 @@ module Utils
         def initialize(work_log_record)
           @record = work_log_record
         end
+
+        def format_tags(tags)
+          tags ? "{#{tags.join(',')}}" : nil
+        end
       end
     end
   end

--- a/src/utils/warehouse/work_logs/request.rb
+++ b/src/utils/warehouse/work_logs/request.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'httparty'
+require 'json'
+
+module Utils
+  module WorkLogs
+    # Encapsulates API calls to the WorkLogs service.
+    class Request
+      # Executes the request to fetch work logs from the API.
+      # It receives the base URL, token, and query parameters dynamically.
+      def self.execute(base_url:, token:, params:)
+        headers = {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        }
+
+        # Performs the GET request to the specific endpoint.
+        HTTParty.get("#{base_url}/api/v1/work-logs", headers: headers, query: params)
+      end
+    end
+  end
+end

--- a/src/utils/warehouse/work_logs/request.rb
+++ b/src/utils/warehouse/work_logs/request.rb
@@ -10,6 +10,9 @@ module Utils
       # Executes the request to fetch work logs from the API.
       # It receives the base URL, token, and query parameters dynamically.
       def self.execute(base_url:, token:, params:)
+        raise ArgumentError, 'base_url is required' if base_url.nil? || base_url.empty?
+        raise ArgumentError, 'token is required' if token.nil? || token.empty?
+
         headers = {
           'Content-Type' => 'application/json',
           'Authorization' => "Bearer #{token}"
@@ -17,6 +20,8 @@ module Utils
 
         # Performs the GET request to the specific endpoint.
         HTTParty.get("#{base_url}/api/v1/work-logs", headers: headers, query: params)
+      rescue HTTParty::Error, StandardError => e
+        raise "Failed to fetch work logs: #{e.message}"
       end
     end
   end

--- a/src/utils/warehouse/work_logs/work_log_formatter.rb
+++ b/src/utils/warehouse/work_logs/work_log_formatter.rb
@@ -10,7 +10,7 @@ module Utils
         def format # rubocop:disable Metrics/MethodLength
           {
             external_work_log_id: @record['id'],
-            duration_minutes: @record['duration'].to_i,
+            duration_minutes: (@record['duration'].to_f * 60).round,
             tags: format_tags(@record['tags']),
             person_id: @record['person_id'],
             project_id: @record['project_id'],

--- a/src/utils/warehouse/work_logs/work_log_formatter.rb
+++ b/src/utils/warehouse/work_logs/work_log_formatter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Utils
+  module Warehouse
+    module WorkLogs
+      # WorkLogFormatter formats work log records for storage in a database.
+      class WorkLogFormatter < Base
+        def format # rubocop:disable Metrics/MethodLength
+          {
+            external_work_log_id: @record['id'],
+            duration_minutes: @record['duration'].to_i,
+            tags: @record['tags'] ? "{#{@record['tags'].join(',')}}" : nil,
+            person_id: @record['person_id'],
+            project_id: @record['project_id'],
+            activity_id: @record['activity_id'],
+            work_item_id: @record['work_item_id'],
+            creation_date: @record['inserted_at'],
+            modification_date: @record['updated_at'],
+            started_at: @record['started_at'],
+            deleted: @record['deleted'],
+            external: @record['external'],
+            description: @record['description']
+          }
+        end
+      end
+    end
+  end
+end

--- a/src/utils/warehouse/work_logs/work_log_formatter.rb
+++ b/src/utils/warehouse/work_logs/work_log_formatter.rb
@@ -11,7 +11,7 @@ module Utils
           {
             external_work_log_id: @record['id'],
             duration_minutes: @record['duration'].to_i,
-            tags: @record['tags'] ? "{#{@record['tags'].join(',')}}" : nil,
+            tags: format_tags(@record['tags']),
             person_id: @record['person_id'],
             project_id: @record['project_id'],
             activity_id: @record['activity_id'],


### PR DESCRIPTION
## Description

This PR introduces a new bot, FetchRecordsFromWorkLogs, designed to consume the WorkLogs endpoint and fetch activity logs for subsequent ingestion into the data warehouse.

The implementation follows the solution proposed in the issue, creating the necessary logic to:
- Connect to the WorkLogs API.
- Fetch records within a given time interval, handling pagination.
- Use a WorkLogFormatter to transform the data into the format required by the warehouse_ingester.
- Add unit tests to validate the bot's functionality.

Fixes #132

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated fetching and synchronization of work log records from an external API into the warehouse database.
  * Added support for work log entities in the warehouse ingestion process.
  * Implemented configurable connection and API settings for work log synchronization.
  * Provided utilities for formatting and handling work log data.

* **Tests**
  * Added comprehensive tests to ensure correct fetching, processing, and storage of work log records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->