### PR TITLE
Add postgres service GitHub release

### DIFF
--- a/db/warehouse_migrations/20250707141419_create_github_releases_table.rb
+++ b/db/warehouse_migrations/20250707141419_create_github_releases_table.rb
@@ -5,12 +5,12 @@ Sequel.migration do
     create_table(:github_releases) do
       uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
       String :external_github_release_id, size: 255, null: false
-      BigInt :repository_id, null: false
-      String :name, size: 255, null: true
-      String :tag_name, size: 255, null: false
-      Boolean :is_prerelease, null: false, default: false
-      DateTime :creation_timestamp, null: false
-      DateTime :pulished_timestamp, null: true
+      BigInt :repository_id, null: true
+      String :name, size: 255, null: false
+      String :tag_name, size: 255, null: true
+      Boolean :is_prerelease, null: false, default: true
+      DateTime :creation_timestamp, null: true
+      DateTime :published_timestamp, null: false
       DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end

--- a/db/warehouse_migrations/20250707141419_create_github_releases_table.rb
+++ b/db/warehouse_migrations/20250707141419_create_github_releases_table.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:github_releases) do
+      uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
+      String :external_github_release_id, size: 255, null: false
+      BigInt :repository_id, null: false
+      String :name, size: 255, null: true
+      String :tag_name, size: 255, null: false
+      Boolean :is_prerelease, null: false, default: false
+      DateTime :creation_timestamp, null: false
+      DateTime :pulished_timestamp, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
+  down do
+    drop_table(:github_releases)
+  end
+end

--- a/spec/services/postgres/github_release_spec.rb
+++ b/spec/services/postgres/github_release_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'rspec'
+require 'securerandom'
+
+require_relative '../../../src/services/postgres/base'
+require_relative '../../../src/services/postgres/github_release'
+require_relative 'test_db_helpers'
+
+RSpec.describe Services::Postgres::GithubRelease do
+  include TestDBHelpers
+
+  # Use an in-memory SQLite database for testing
+  let(:db) { Sequel.sqlite }
+  let(:config) { { adapter: 'sqlite', database: ':memory:' } }
+
+  let(:service) { described_class.new(config) }
+
+  before(:each) do
+    db.drop_table?(:github_releases)
+
+    create_github_releases_table(db)
+
+    allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
+  end
+
+  describe '#insert' do
+    it 'creates a new github_release and returns its ID' do
+      params = {
+        external_github_release_id: 'ghr-1',
+        repository_id: 12_345,
+        tag_name: 'v1.0.0',
+        creation_timestamp: Time.now,
+        name: 'First Release'
+      }
+      id = service.insert(params)
+      release = service.find(id)
+
+      expect(release).not_to be_nil
+      expect(release[:external_github_release_id]).to eq('ghr-1')
+      expect(release[:repository_id]).to eq(12_345)
+      expect(release[:tag_name]).to eq('v1.0.0')
+      expect(release[:name]).to eq('First Release')
+    end
+  end
+
+  describe '#update' do
+    let!(:release_id) do
+      service.insert(
+        external_github_release_id: 'ghr-2',
+        repository_id: 54_321,
+        tag_name: 'v1.1.0',
+        name: 'Initial Release',
+        creation_timestamp: Time.now
+      )
+    end
+
+    it 'updates a github_release by its ID' do
+      service.update(release_id, { name: 'Updated Release Name', is_prerelease: true })
+      updated_release = service.find(release_id)
+
+      expect(updated_release[:name]).to eq('Updated Release Name')
+      expect(updated_release[:is_prerelease]).to be true
+      expect(updated_release[:repository_id]).to eq(54_321)
+    end
+
+    it 'can update the repository_id' do
+      service.update(release_id, { repository_id: 99_999 })
+      updated_release = service.find(release_id)
+
+      expect(updated_release[:repository_id]).to eq(99_999)
+    end
+
+    it 'raises an ArgumentError if no ID is provided' do
+      # Suppress console output from the `handle_error` method for this specific test.
+      allow($stdout).to receive(:write)
+
+      expect do
+        service.update(nil, { name: 'No ID' })
+      end.to raise_error(ArgumentError, 'GithubRelease id is required to update')
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a github_release by ID' do
+      id_to_delete = service.insert(
+        external_github_release_id: 'ghr-3',
+        repository_id: 67_890,
+        tag_name: 'v2.0.0-beta',
+        creation_timestamp: Time.now
+      )
+
+      expect { service.delete(id_to_delete) }.to change { service.query.size }.by(-1)
+      expect(service.find(id_to_delete)).to be_nil
+    end
+  end
+
+  describe '#query' do
+    before do
+      service.insert(
+        external_github_release_id: 'ghr-4',
+        repository_id: 111,
+        tag_name: 'v3.0.0',
+        name: 'Find Me',
+        creation_timestamp: Time.now
+      )
+      service.insert(
+        external_github_release_id: 'ghr-5',
+        repository_id: 222,
+        tag_name: 'v3.0.1',
+        name: 'Another One',
+        creation_timestamp: Time.now
+      )
+    end
+
+    it 'queries github_releases by a specific condition' do
+      results = service.query(repository_id: 111)
+      expect(results.size).to eq(1)
+      expect(results.first[:name]).to eq('Find Me')
+    end
+
+    it 'returns all releases with empty conditions' do
+      expect(service.query.size).to eq(2)
+    end
+  end
+end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -173,4 +173,19 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
+
+  def create_github_releases_table(db) # rubocop:disable Metrics/MethodLength
+    db.create_table(:github_releases) do
+      primary_key :id
+      String :external_github_release_id, size: 255, null: false
+      BigInt :repository_id, null: false
+      String :name, size: 255, null: true
+      String :tag_name, size: 255, null: false
+      Boolean :is_prerelease, null: false, default: false
+      DateTime :creation_timestamp, null: false
+      DateTime :pulished_timestamp, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
 end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -183,7 +183,7 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       String :tag_name, size: 255, null: false
       Boolean :is_prerelease, null: false, default: false
       DateTime :creation_timestamp, null: false
-      DateTime :pulished_timestamp, null: true
+      DateTime :published_timestamp, null: true
       DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end

--- a/src/services/postgres/github_release.rb
+++ b/src/services/postgres/github_release.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Services
+  module Postgres
+    ##
+    # GithubRelease Service for PostgreSQL
+    #
+    # Provides CRUD operations for the 'github_releases' table using the Base service.
+    class GithubRelease < Services::Postgres::Base
+      ATTRIBUTES = %i[
+        external_github_release_id repository_id name tag_name
+        is_prerelease creation_timestamp pulished_timestamp
+      ].freeze
+
+      TABLE = :github_releases
+
+      def insert(params)
+        transaction { insert_item(TABLE, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def update(id, params)
+        raise ArgumentError, 'GithubRelease id is required to update' unless id
+
+        transaction { update_item(TABLE, id, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def delete(id)
+        transaction { delete_item(TABLE, id) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def find(id)
+        find_item(TABLE, id)
+      end
+
+      def query(conditions = {})
+        query_item(TABLE, conditions)
+      end
+
+      private
+
+      def handle_error(error)
+        puts "[GithubRelease Service ERROR] #{error.class}: #{error.message}\nBacktrace: #{error.backtrace.join("\n")}"
+        raise error
+      end
+    end
+  end
+end

--- a/src/services/postgres/github_release.rb
+++ b/src/services/postgres/github_release.rb
@@ -11,7 +11,7 @@ module Services
     class GithubRelease < Services::Postgres::Base
       ATTRIBUTES = %i[
         external_github_release_id repository_id name tag_name
-        is_prerelease creation_timestamp pulished_timestamp
+        is_prerelease creation_timestamp published_timestamp
       ].freeze
 
       TABLE = :github_releases


### PR DESCRIPTION
## Description

This pull request introduces a new PostgreSQL service to manage GitHub releases within the data warehouse. The implementation includes:

- A new database migration to create the github_releases table.
- A GithubRelease service that inherits from Base to handle CRUD operations (create, update, delete).
- A complete RSpec test file to ensure the service functions correctly.

Fixes #143


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x}] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing GitHub release records, including creating, updating, deleting, and querying releases.
* **Tests**
  * Introduced comprehensive tests for GitHub release management, covering all core operations.
* **Chores**
  * Added database migration for GitHub releases.
  * Included test helpers for creating the GitHub releases table in test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->