### PR TITLE
Add GitHub pull requests services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     faraday-retry (2.3.2)
       faraday (~> 2.0)
     ffi (1.17.2-x64-mingw-ucrt)
-    ffi (1.17.2-x86_64-linux-gnu)
     gems (1.3.0)
     gmail_xoauth (0.4.3)
       oauth (>= 0.3.6)
@@ -200,7 +199,6 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
-    pg (1.5.9)
     pg (1.5.9-x64-mingw-ucrt)
     prism (1.4.0)
     public_suffix (6.0.2)
@@ -277,7 +275,6 @@ GEM
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     sqlite3 (2.7.1-x64-mingw-ucrt)
-    sqlite3 (2.7.1-x86_64-linux-gnu)
     telegram-bot-ruby (1.0.0)
       dry-struct (~> 1.6)
       faraday (~> 2.0)
@@ -305,7 +302,6 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
-  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     faraday-retry (2.3.2)
       faraday (~> 2.0)
     ffi (1.17.2-x64-mingw-ucrt)
+    ffi (1.17.2-x86_64-linux-gnu)
     gems (1.3.0)
     gmail_xoauth (0.4.3)
       oauth (>= 0.3.6)
@@ -199,6 +200,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     pg (1.5.9-x64-mingw-ucrt)
     prism (1.4.0)
     public_suffix (6.0.2)
@@ -275,6 +277,7 @@ GEM
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     sqlite3 (2.7.1-x64-mingw-ucrt)
+    sqlite3 (2.7.1-x86_64-linux-gnu)
     telegram-bot-ruby (1.0.0)
       dry-struct (~> 1.6)
       faraday (~> 2.0)
@@ -302,6 +305,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3

--- a/db/warehouse_migrations/20250708094341_create_github_pull_requests_table.rb
+++ b/db/warehouse_migrations/20250708094341_create_github_pull_requests_table.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:github_pull_requests) do
+      uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
+      BigInt :external_github_pull_request_id, size: 255, null: false
+      BigInt :repository_id, null: false
+      foreign_key :release_id, :github_releases, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :issue_id, :github_issues, type: :uuid, null: true, on_delete: :cascade
+      column :related_issue_ids, 'bigint[]', null: true
+      column :reviews_data, :jsonb, null: true
+      String :title, size: 255, null: false
+      DateTime :creation_date, null: false
+      DateTime :merge_date, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
+  down do
+    drop_table(:github_pull_requests)
+  end
+end

--- a/db/warehouse_migrations/20250708094341_create_github_pull_requests_table.rb
+++ b/db/warehouse_migrations/20250708094341_create_github_pull_requests_table.rb
@@ -4,7 +4,7 @@ Sequel.migration do
   up do
     create_table(:github_pull_requests) do
       uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
-      BigInt :external_github_pull_request_id, size: 255, null: false
+      BigInt :external_github_pull_request_id, null: false
       BigInt :repository_id, null: false
       foreign_key :release_id, :github_releases, type: :uuid, null: true, on_delete: :cascade
       foreign_key :issue_id, :github_issues, type: :uuid, null: true, on_delete: :cascade

--- a/spec/services/postgres/github_pull_request_spec.rb
+++ b/spec/services/postgres/github_pull_request_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'rspec'
+require 'securerandom'
+require 'json'
+
+require_relative '../../../src/services/postgres/base'
+require_relative '../../../src/services/postgres/github_pull_request'
+require_relative '../../../src/services/postgres/github_release'
+require_relative '../../../src/services/postgres/github_issue'
+require_relative '../../../src/services/postgres/person'
+require_relative 'test_db_helpers'
+
+RSpec.describe Services::Postgres::GithubPullRequest do
+  include TestDBHelpers
+
+  let(:db) { Sequel.sqlite }
+  let(:config) { { adapter: 'sqlite', database: ':memory:' } }
+
+  let(:service) { described_class.new(config) }
+  let(:release_service) { Services::Postgres::GithubRelease.new(config) }
+  let(:issue_service) { Services::Postgres::GithubIssue.new(config) }
+  let(:person_service) { Services::Postgres::Person.new(config) }
+
+  before(:each) do
+    allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
+
+    db.drop_table?(:github_pull_requests)
+    db.drop_table?(:github_releases)
+    db.drop_table?(:github_issues)
+    db.drop_table?(:persons)
+
+    create_persons_table(db)
+    create_github_issues_table(db)
+    create_github_releases_table(db)
+    create_github_pull_requests_table(db)
+
+    @person_id = person_service.insert(external_person_id: 'person-1', full_name: 'Test User')
+    @release_id = release_service.insert(external_github_release_id: 'ghr-1', repository_id: 1, tag_name: 'v1.0',
+                                         creation_timestamp: Time.now)
+    @issue_id = issue_service.insert(external_github_issue_id: 'issue-1', repository_id: 1, person_id: @person_id)
+  end
+
+  describe '#insert' do
+    it 'creates a new pull request and returns its ID' do
+      params = {
+        external_github_pull_request_id: 'pr-1',
+        repository_id: 123,
+        title: 'My First PR',
+        creation_date: Time.now
+      }
+      id = service.insert(params)
+      pr = service.find(id)
+
+      expect(pr).not_to be_nil
+      expect(pr[:external_github_pull_request_id]).to eq('pr-1')
+      expect(pr[:title]).to eq('My First PR')
+    end
+
+    it 'assigns foreign keys for release and issue using external ids' do
+      params = {
+        external_github_pull_request_id: 'pr-2',
+        repository_id: 1,
+        title: 'PR with Relations',
+        creation_date: Time.now,
+        external_release_id: 'ghr-1',
+        external_issue_id: 'issue-1'
+      }
+      id = service.insert(params)
+      pr = service.find(id)
+
+      expect(pr[:release_id]).to eq(@release_id)
+      expect(pr[:issue_id]).to eq(@issue_id)
+    end
+
+    it 'handles array and json fields' do
+      params = {
+        external_github_pull_request_id: 'pr-3',
+        repository_id: 1,
+        title: 'PR with Data',
+        creation_date: Time.now,
+        related_issue_ids: JSON.generate([10, 20, 30]),
+        reviews_data: JSON.generate({ state: 'APPROVED', user: 'test-user' })
+      }
+      id = service.insert(params)
+      pr = service.find(id)
+
+      expect(pr[:related_issue_ids]).to eq('[10,20,30]')
+      expect(pr[:reviews_data]).to eq('{"state":"APPROVED","user":"test-user"}')
+    end
+  end
+
+  describe '#update' do
+    let!(:pr_id) do
+      service.insert(
+        external_github_pull_request_id: 'pr-4',
+        repository_id: 1,
+        title: 'Initial Title',
+        creation_date: Time.now
+      )
+    end
+
+    it 'updates a pull request by its ID' do
+      update_params = {
+        title: 'Updated Title',
+        merge_date: Time.now
+      }
+      service.update(pr_id, update_params)
+      updated_pr = service.find(pr_id)
+
+      expect(updated_pr[:title]).to eq('Updated Title')
+      expect(updated_pr[:merge_date]).not_to be_nil
+    end
+
+    it 'reassigns foreign keys on update' do
+      new_issue_id = issue_service.insert(external_github_issue_id: 'issue-2', repository_id: 1, person_id: @person_id)
+      service.update(pr_id, { external_issue_id: 'issue-2' })
+      updated_pr = service.find(pr_id)
+
+      expect(updated_pr[:issue_id]).to eq(new_issue_id)
+    end
+
+    it 'raises an ArgumentError if no ID is provided' do
+      allow($stdout).to receive(:write)
+      expect do
+        service.update(nil, { title: 'No ID' })
+      end.to raise_error(ArgumentError, 'GithubPullRequest id is required to update')
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a pull request by ID' do
+      id_to_delete = service.insert(
+        external_github_pull_request_id: 'pr-5',
+        repository_id: 1,
+        title: 'To Be Deleted',
+        creation_date: Time.now
+      )
+      expect { service.delete(id_to_delete) }.to change { service.query.size }.by(-1)
+      expect(service.find(id_to_delete)).to be_nil
+    end
+  end
+
+  describe '#query' do
+    it 'queries pull requests by a specific condition' do
+      service.insert(
+        external_github_pull_request_id: 'pr-6',
+        repository_id: 999,
+        title: 'Find Me',
+        creation_date: Time.now
+      )
+      results = service.query(repository_id: 999)
+      expect(results.size).to eq(1)
+      expect(results.first[:title]).to eq('Find Me')
+    end
+  end
+end

--- a/spec/services/postgres/github_pull_request_spec.rb
+++ b/spec/services/postgres/github_pull_request_spec.rb
@@ -26,27 +26,26 @@ RSpec.describe Services::Postgres::GithubPullRequest do
   before(:each) do
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
 
-    db.drop_table?(:github_pull_requests)
-    db.drop_table?(:github_releases)
-    db.drop_table?(:github_issues)
-    db.drop_table?(:persons)
+    db.drop_table?(:github_pull_requests, :github_releases, :github_issues, :persons, :domains)
 
+    create_domains_table(db)
     create_persons_table(db)
     create_github_issues_table(db)
     create_github_releases_table(db)
     create_github_pull_requests_table(db)
 
     @person_id = person_service.insert(external_person_id: 'person-1', full_name: 'Test User')
-    @release_id = release_service.insert(external_github_release_id: 'ghr-1', repository_id: 1, tag_name: 'v1.0',
+    @release_id = release_service.insert(external_github_release_id: 'ghr-1', repository_id: 1, tag_name: 'v1.0-test',
                                          creation_timestamp: Time.now)
-    @issue_id = issue_service.insert(external_github_issue_id: 'issue-1', repository_id: 1, person_id: @person_id)
+    @issue_id = issue_service.insert(external_github_issue_id: 123, repository_id: 1, person_id: @person_id)
   end
 
   describe '#insert' do
     it 'creates a new pull request and returns its ID' do
       params = {
-        external_github_pull_request_id: 'pr-1',
-        repository_id: 123,
+        external_github_pull_request_id: 1,
+        repository_id: 100,
+        external_github_release_id: 'ghr-1',
         title: 'My First PR',
         creation_date: Time.now
       }
@@ -54,18 +53,18 @@ RSpec.describe Services::Postgres::GithubPullRequest do
       pr = service.find(id)
 
       expect(pr).not_to be_nil
-      expect(pr[:external_github_pull_request_id]).to eq('pr-1')
+      expect(pr[:external_github_pull_request_id]).to eq(1)
       expect(pr[:title]).to eq('My First PR')
     end
 
     it 'assigns foreign keys for release and issue using external ids' do
       params = {
-        external_github_pull_request_id: 'pr-2',
+        external_github_pull_request_id: 2,
         repository_id: 1,
         title: 'PR with Relations',
         creation_date: Time.now,
-        external_release_id: 'ghr-1',
-        external_issue_id: 'issue-1'
+        external_github_release_id: 'ghr-1',
+        external_github_issue_id: 123
       }
       id = service.insert(params)
       pr = service.find(id)
@@ -76,17 +75,18 @@ RSpec.describe Services::Postgres::GithubPullRequest do
 
     it 'handles array and json fields' do
       params = {
-        external_github_pull_request_id: 'pr-3',
+        external_github_pull_request_id: 3,
         repository_id: 1,
         title: 'PR with Data',
         creation_date: Time.now,
-        related_issue_ids: JSON.generate([10, 20, 30]),
-        reviews_data: JSON.generate({ state: 'APPROVED', user: 'test-user' })
+        related_issue_ids: JSON.generate([10, 20]),
+        reviews_data: JSON.generate({ state: 'APPROVED', user: 'test-user' }),
+        external_github_release_id: 'ghr-1'
       }
       id = service.insert(params)
       pr = service.find(id)
 
-      expect(pr[:related_issue_ids]).to eq('[10,20,30]')
+      expect(pr[:related_issue_ids]).to eq('[10,20]')
       expect(pr[:reviews_data]).to eq('{"state":"APPROVED","user":"test-user"}')
     end
   end
@@ -94,19 +94,16 @@ RSpec.describe Services::Postgres::GithubPullRequest do
   describe '#update' do
     let!(:pr_id) do
       service.insert(
-        external_github_pull_request_id: 'pr-4',
+        external_github_pull_request_id: 4,
         repository_id: 1,
         title: 'Initial Title',
-        creation_date: Time.now
+        creation_date: Time.now,
+        external_github_release_id: 'ghr-1'
       )
     end
 
     it 'updates a pull request by its ID' do
-      update_params = {
-        title: 'Updated Title',
-        merge_date: Time.now
-      }
-      service.update(pr_id, update_params)
+      service.update(pr_id, { title: 'Updated Title', merge_date: Time.now })
       updated_pr = service.find(pr_id)
 
       expect(updated_pr[:title]).to eq('Updated Title')
@@ -114,8 +111,8 @@ RSpec.describe Services::Postgres::GithubPullRequest do
     end
 
     it 'reassigns foreign keys on update' do
-      new_issue_id = issue_service.insert(external_github_issue_id: 'issue-2', repository_id: 1, person_id: @person_id)
-      service.update(pr_id, { external_issue_id: 'issue-2' })
+      new_issue_id = issue_service.insert(external_github_issue_id: 456, repository_id: 1, person_id: @person_id)
+      service.update(pr_id, { external_github_issue_id: 456 })
       updated_pr = service.find(pr_id)
 
       expect(updated_pr[:issue_id]).to eq(new_issue_id)
@@ -123,19 +120,19 @@ RSpec.describe Services::Postgres::GithubPullRequest do
 
     it 'raises an ArgumentError if no ID is provided' do
       allow($stdout).to receive(:write)
-      expect do
-        service.update(nil, { title: 'No ID' })
-      end.to raise_error(ArgumentError, 'GithubPullRequest id is required to update')
+      expect { service.update(nil, { title: 'No ID' }) }
+        .to raise_error(ArgumentError, 'GithubPullRequest id is required to update')
     end
   end
 
   describe '#delete' do
     it 'deletes a pull request by ID' do
       id_to_delete = service.insert(
-        external_github_pull_request_id: 'pr-5',
+        external_github_pull_request_id: 5,
         repository_id: 1,
         title: 'To Be Deleted',
-        creation_date: Time.now
+        creation_date: Time.now,
+        external_github_release_id: 'ghr-1'
       )
       expect { service.delete(id_to_delete) }.to change { service.query.size }.by(-1)
       expect(service.find(id_to_delete)).to be_nil
@@ -145,10 +142,11 @@ RSpec.describe Services::Postgres::GithubPullRequest do
   describe '#query' do
     it 'queries pull requests by a specific condition' do
       service.insert(
-        external_github_pull_request_id: 'pr-6',
+        external_github_pull_request_id: 6,
         repository_id: 999,
         title: 'Find Me',
-        creation_date: Time.now
+        creation_date: Time.now,
+        external_github_release_id: 'ghr-1'
       )
       results = service.query(repository_id: 999)
       expect(results.size).to eq(1)

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -203,4 +203,21 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
+
+  def create_github_pull_requests_table(db) # rubocop:disable Metrics/MethodLength
+    db.create_table(:github_pull_requests) do
+      primary_key :id
+      BigInt :external_github_pull_request_id, null: false, unique: true
+      BigInt :repository_id, null: false
+      foreign_key :release_id, :github_releases, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :issue_id, :github_issues, type: :uuid, null: true, on_delete: :cascade
+      column :related_issue_ids, 'bigint[]', null: true
+      column :reviews_data, :jsonb, null: true
+      String :title, size: 255, null: false
+      DateTime :creation_date, null: false
+      DateTime :merge_date, null: true
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
 end

--- a/src/services/postgres/github_pull_request.rb
+++ b/src/services/postgres/github_pull_request.rb
@@ -17,8 +17,8 @@ module Services
       TABLE = :github_pull_requests
 
       RELATIONS = [
-        { service: GithubRelease, external: :external_release_id, internal: :release_id },
-        { service: GithubIssue, external: :external_issue_id, internal: :issue_id }
+        { service: GithubRelease, external: :external_github_release_id, internal: :release_id },
+        { service: GithubIssue, external: :external_github_issue_id, internal: :issue_id }
       ].freeze
 
       def insert(params)

--- a/src/services/postgres/github_pull_request.rb
+++ b/src/services/postgres/github_pull_request.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'github_release'
+require_relative 'github_issue'
+
+module Services
+  module Postgres
+    ##
+    # GithubPullRequest Service for PostgreSQL
+    #
+    # Provides CRUD operations for the 'github_pull_requests' table using the Base service.
+    class GithubPullRequest < Services::Postgres::Base
+      ATTRIBUTES = %i[external_github_pull_request_id repository_id release_id issue_id related_issue_ids reviews_data
+                      title creation_date merge_date].freeze
+
+      TABLE = :github_pull_requests
+
+      RELATIONS = [
+        { service: GithubRelease, external: :external_release_id, internal: :release_id },
+        { service: GithubIssue, external: :external_issue_id, internal: :issue_id }
+      ].freeze
+
+      def insert(params)
+        assign_relations(params)
+
+        transaction do
+          insert_item(TABLE, params)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def update(id, params)
+        raise ArgumentError, 'GithubPullRequest id is required to update' unless id
+
+        assign_relations(params)
+
+        transaction do
+          update_item(TABLE, id, params)
+        end
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def delete(id)
+        transaction { delete_item(TABLE, id) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def find(id)
+        find_item(TABLE, id)
+      end
+
+      def query(conditions = {})
+        query_item(TABLE, conditions)
+      end
+
+      private
+
+      def handle_error(error)
+        puts "[GithubPullRequest Service ERROR] #{error.class}: #{error.message}"
+        raise error
+      end
+    end
+  end
+end

--- a/src/services/postgres/github_release.rb
+++ b/src/services/postgres/github_release.rb
@@ -45,7 +45,7 @@ module Services
       private
 
       def handle_error(error)
-        puts "[GithubRelease Service ERROR] #{error.class}: #{error.message}\nBacktrace: #{error.backtrace.join("\n")}"
+        puts "[GithubRelease Service ERROR] #{error.class}: #{error.message}}"
         raise error
       end
     end

--- a/src/services/postgres/github_release.rb
+++ b/src/services/postgres/github_release.rb
@@ -45,7 +45,7 @@ module Services
       private
 
       def handle_error(error)
-        puts "[GithubRelease Service ERROR] #{error.class}: #{error.message}}"
+        puts "[GithubRelease Service ERROR] #{error.class}: #{error.message}"
         raise error
       end
     end


### PR DESCRIPTION
## Description

This pull request introduces a new PostgreSQL service to manage GitHub pull requests within the data warehouse.

The implementation includes:

- A new database migration to create the github_pull_requests table with all necessary columns and foreign key relationships.
- A GithubPullRequest service that inherits from the Base class to handle all CRUD operations.
- A comprehensive RSpec test file to validate the service's functionality.

Fixes #149 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing GitHub pull requests, including creation, updating, deletion, and querying of pull request records.
* **Tests**
  * Introduced comprehensive tests for pull request management, ensuring correct handling of related releases, issues, and data integrity.
* **Chores**
  * Updated database schema to include a table for GitHub pull requests with relevant fields and associations.
* **Refactor**
  * Improved error messages for release management by simplifying error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->