### PR TITLE
Add calendar events service

### DIFF
--- a/db/warehouse_migrations/20250716162117_create_calendar_events_table.rb
+++ b/db/warehouse_migrations/20250716162117_create_calendar_events_table.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:calendar_events) do
+      uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
+      String :external_calendar_event_id, size: 255, null: false
+      String :summary, size: 1000, null: true
+      Integer :duration_minutes, null: false
+      DateTime :start_time, null: false
+      DateTime :end_time, null: false
+      DateTime :creation_timestamp, null: false
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
+  down do
+    drop_table(:calendar_events)
+  end
+end

--- a/spec/services/postgres/calendar_event_spec.rb
+++ b/spec/services/postgres/calendar_event_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'rspec'
+require_relative '../../../src/services/postgres/base'
+require_relative '../../../src/services/postgres/calendar_event'
+require_relative 'test_db_helpers'
+
+RSpec.describe Services::Postgres::CalendarEvent do
+  include TestDBHelpers
+
+  let(:db) { Sequel.sqlite }
+  let(:config) { { adapter: 'sqlite', database: ':memory:' } }
+  let(:service) { described_class.new(config) }
+
+  before(:each) do
+    db.drop_table?(:calendar_events)
+    create_calendar_events_table(db)
+
+    allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
+  end
+
+  describe '#insert' do
+    it 'creates a new calendar_event and returns its ID' do
+      params = {
+        external_calendar_event_id: 'evt-123',
+        summary: 'Test Event',
+        duration_minutes: 60,
+        start_time: Time.now,
+        end_time: Time.now + 3600,
+        creation_timestamp: Time.now - 86_400
+      }
+      id = service.insert(params)
+      event = service.find(id)
+
+      expect(event[:summary]).to eq('Test Event')
+      expect(event[:external_calendar_event_id]).to eq('evt-123')
+      expect(event[:duration_minutes]).to eq(60)
+    end
+  end
+
+  describe '#update' do
+    let(:event_id) do
+      service.insert(
+        external_calendar_event_id: 'evt-to-update',
+        summary: 'Old Summary',
+        duration_minutes: 30,
+        start_time: Time.now,
+        end_time: Time.now + 1800,
+        creation_timestamp: Time.now - 86_400
+      )
+    end
+
+    it 'updates a calendar_event by ID' do
+      service.update(event_id, { summary: 'Updated Summary', duration_minutes: 45 })
+      updated = service.find(event_id)
+
+      expect(updated[:summary]).to eq('Updated Summary')
+      expect(updated[:duration_minutes]).to eq(45)
+    end
+
+    it 'raises an error if no ID is provided' do
+      expect { service.update(nil, { summary: 'No ID' }) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a calendar_event by ID' do
+      id = service.insert(external_calendar_event_id: 'evt-to-delete', summary: 'To Delete', duration_minutes: 15,
+                          start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+
+      expect { service.delete(id) }.to change { service.query.size }.by(-1)
+      expect(service.find(id)).to be_nil
+    end
+  end
+
+  describe '#find' do
+    it 'finds a calendar_event by ID' do
+      id = service.insert(external_calendar_event_id: 'evt-to-find', summary: 'Find Me', duration_minutes: 10,
+                          start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+      found = service.find(id)
+
+      expect(found[:id]).to eq(id)
+      expect(found[:summary]).to eq('Find Me')
+    end
+  end
+
+  describe '#query' do
+    before do
+      service.insert(external_calendar_event_id: 'evt-query-1', summary: 'Query Me', duration_minutes: 5,
+                     start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+      service.insert(external_calendar_event_id: 'evt-query-2', summary: 'Another Event', duration_minutes: 25,
+                     start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+    end
+
+    it 'queries calendar_events by condition' do
+      results = service.query(summary: 'Query Me')
+      expect(results.size).to eq(1)
+      expect(results.first[:external_calendar_event_id]).to eq('evt-query-1')
+    end
+
+    it 'returns all calendar_events with empty conditions' do
+      expect(service.query.size).to eq(2)
+    end
+  end
+end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -220,4 +220,18 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
     end
   end
+
+  def create_calendar_events_table(db) # rubocop:disable Metrics/MethodLength
+    db.create_table(:calendar_events) do
+      primary_key :id
+      String :external_calendar_event_id, size: 255, null: false
+      String :summary, size: 1000, null: true
+      Integer :duration_minutes, null: false
+      DateTime :start_time, null: false
+      DateTime :end_time, null: false
+      DateTime :creation_timestamp, null: false
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
 end

--- a/src/services/postgres/calendar_event.rb
+++ b/src/services/postgres/calendar_event.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Services
+  module Postgres
+    ##
+    # CalendarEvent Service for PostgreSQL
+    #
+    # Provides CRUD operations for the 'calendar_events' table using the Base service.
+    class CalendarEvent < Services::Postgres::Base
+      ATTRIBUTES = %i[external_calendar_event_id summary duration_minutes start_time end_time
+                      creation_timestamp].freeze
+
+      TABLE = :calendar_events
+
+      def insert(params)
+        transaction { insert_item(TABLE, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def update(id, params)
+        raise ArgumentError, 'Calendar event id is required to update' unless id
+
+        transaction { update_item(TABLE, id, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def delete(id)
+        transaction { delete_item(TABLE, id) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def find(id)
+        find_item(TABLE, id)
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def query(conditions = {})
+        query_item(TABLE, conditions)
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      private
+
+      def handle_error(error)
+        puts "[CalendarEvent Service ERROR] #{error.class}: #{error.message}"
+        raise error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR introduces the CalendarEventService to manage calendar events from Google Calendar within our PostgreSQL data warehouse.

The implementation includes:

- A database migration to create the calendar_events table.
- A new PostgreSQL service that inherits from Services::Postgres::Base to handle insert, update, delete, find, and query operations.
- A full suite of RSpec tests to ensure the service's functionality and reliability.

Fixes #160

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
