### PR TITLE
Standardize Error Handling in Fetch Bots

### DIFF
--- a/spec/implementations/warehouse/github/fetch_releases_from_github_spec.rb
+++ b/spec/implementations/warehouse/github/fetch_releases_from_github_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Implementation::FetchReleasesFromGithub do
       it 'returns an error hash' do
         result = bot.process
         expect(result).to have_key(:error)
-        expect(result[:error]).to eq('Authentication failed')
+        expect(result.dig(:error, :message)).to eq('Authentication failed')
       end
     end
 

--- a/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
+++ b/spec/implementations/warehouse/work_logs/fetch_records_from_work_logs_spec.rb
@@ -85,8 +85,10 @@ RSpec.describe Implementation::FetchRecordsFromWorkLogs do
         allow(Utils::WorkLogs::Request).to receive(:execute).and_return(error_response)
       end
 
-      it 'raises a runtime error with a specific message' do
-        expect { subject.process }.to raise_error(RuntimeError, 'Error fetching data: 500 - Server Error')
+      it 'returns a formatted error hash' do
+        result = subject.process
+        expect(result).to have_key(:error)
+        expect(result.dig(:error, :message)).to eq('Error fetching data: 500 - Server Error')
       end
     end
   end

--- a/src/implementations/fetch_hired_persons_from_notion.rb
+++ b/src/implementations/fetch_hired_persons_from_notion.rb
@@ -49,6 +49,8 @@ module Implementation
     end
 
     def write
+      return @shared_storage_writer.write(process_response) if process_response[:error]
+
       content = process_response.dig(:success, :content) || []
       paged_entities = content.each_slice(PAGE_SIZE).to_a
 
@@ -118,10 +120,7 @@ module Implementation
     def date_filter
       return [] if read_response.inserted_at.nil?
 
-      [{
-        timestamp: :last_edited_time,
-        last_edited_time: { on_or_after: read_response.inserted_at }
-      }]
+      [{ timestamp: :last_edited_time, last_edited_time: { on_or_after: read_response.inserted_at } }]
     end
 
     def build_record(content:, page_index:, total_pages:, total_records:)
@@ -137,12 +136,7 @@ module Implementation
     end
 
     def error_response(response)
-      {
-        error: {
-          message: response.parsed_response,
-          status_code: response.code
-        }
-      }
+      { error: { message: response.parsed_response, status_code: response.code } }
     end
   end
 end

--- a/src/implementations/fetch_records_from_work_logs.rb
+++ b/src/implementations/fetch_records_from_work_logs.rb
@@ -50,9 +50,13 @@ module Implementation
       normalized_content = normalize_response(logs)
 
       { success: { type: process_options[:entity], content: normalized_content } }
+    rescue StandardError => e
+      error_response(e)
     end
 
     def write
+      return @shared_storage_writer.write(process_response) if process_response[:error]
+
       content = process_response.dig(:success, :content) || []
       paged_entities = content.each_slice(PAGE_SIZE).to_a
 
@@ -109,6 +113,10 @@ module Implementation
           total_records: total_records
         }
       }
+    end
+
+    def error_response(response)
+      { error: { message: response.message } }
     end
   end
 end

--- a/src/implementations/fetch_releases_from_github.rb
+++ b/src/implementations/fetch_releases_from_github.rb
@@ -45,7 +45,7 @@ module Implementation
     #
     def process
       client_response = initialize_client
-      return client_response if client_response[:error]
+      return error_response(client_response) if client_response[:error]
 
       client = client_response[:client]
       repositories = fetch_repositories(client)
@@ -57,6 +57,8 @@ module Implementation
     # Orchestrates the writing of processed data to the configured shared storage.
     #
     def write
+      return @shared_storage_writer.write(process_response) if process_response[:error]
+
       content = process_response.dig(:success, :content) || []
       return if content.empty?
 
@@ -126,6 +128,10 @@ module Implementation
           total_records: total_records
         }
       }
+    end
+
+    def error_response(response)
+      { error: { message: response[:error] } }
     end
   end
 end

--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -159,7 +159,7 @@ module UseCasesExecution
       { path: "#{__dir__}/warehouse/github/fetch_kommit_co_issues_from_github.rb", time: ['06:05'] },
       { path: "#{__dir__}/warehouse/github/fetch_kommitters_issues_from_github.rb", time: ['06:10'] },
       { path: "#{__dir__}/warehouse/github/fetch_kommit_co_pull_requests_from_github.rb", time: ['06:15'] },
-      { path: "#{__dir__}/warehouse/github/fetch_kommitters_pull_requests_from_github", time: ['06:20'] },
+      { path: "#{__dir__}/warehouse/github/fetch_kommitters_pull_requests_from_github.rb", time: ['06:20'] },
       { path: "#{__dir__}/warehouse/notion/warehouse_ingester.rb", interval: 3_600_000 }
     ].freeze
   end


### PR DESCRIPTION
## Description

This PR standardizes the error handling mechanism across all data fetcher bots (including GitHub and WorkLogs bots) to align with the BAS gem's expected format.

Previously, error management was inconsistent, which made debugging and tracing failures difficult. This refactor ensures that all bots now catch exceptions during the process step and return a standardized { error: { ... } } hash. The write method has also been updated to correctly persist these errors to shared storage.

This change significantly improves the system's reliability and maintainability.

Fixes #164

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
