### PR TITLE
Implement workspace auth service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ node_modules
 # Environment keys
 env.yml
 .tool-versions
+google_credentials.json
 
 # Claude code
 # Project level claude folder may be different for each user

--- a/spec/services/google_work_space/base_spec.rb
+++ b/spec/services/google_work_space/base_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'googleauth'
+require 'stringio'
+require_relative '../../../src/services/google_work_space/base'
+
+RSpec.describe Service::GoogleWorkSpace::Base do
+  let(:admin_email) { 'test-admin@example.com' }
+  let(:scope) { 'https://www.googleapis.com/auth/any_scope' }
+
+  let(:keyfile_content) { '{"private_key": "fake"}' }
+  let(:config) do
+    {
+      keyfile_path: '/fake/path/credentials.json',
+      admin_email: admin_email
+    }
+  end
+
+  let(:mock_authorizer) { instance_double(Google::Auth::ServiceAccountCredentials) }
+  let(:mock_impersonated_credentials) { instance_double(Google::Auth::ServiceAccountCredentials) }
+
+  before do
+    allow(File).to receive(:open).and_return(StringIO.new(keyfile_content))
+
+    allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(mock_authorizer)
+    allow(mock_authorizer).to receive(:dup).and_return(mock_impersonated_credentials)
+    allow(mock_impersonated_credentials).to receive(:sub=)
+    allow(mock_impersonated_credentials).to receive(:fetch_access_token!)
+  end
+
+  describe '#initialize' do
+    it 'authenticates using the provided service account credentials' do
+      expect(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).with(
+        json_key_io: instance_of(StringIO),
+        scope: scope
+      )
+      described_class.new(config, scope: scope)
+    end
+
+    it 'always impersonates the admin user' do
+      expect(mock_impersonated_credentials).to receive(:sub=).with(admin_email)
+      described_class.new(config, scope: scope)
+    end
+
+    it 'fetches an access token for the impersonated user' do
+      expect(mock_impersonated_credentials).to receive(:fetch_access_token!)
+      described_class.new(config, scope: scope)
+    end
+
+    it 'assigns the final impersonated credentials to the @credentials instance variable' do
+      service = described_class.new(config, scope: scope)
+      expect(service.credentials).to eq(mock_impersonated_credentials)
+    end
+  end
+end

--- a/src/services/google_work_space/base.rb
+++ b/src/services/google_work_space/base.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'googleauth'
+
+module Service
+  module GoogleWorkSpace
+    # Base class for Google Workspace API services.
+    #
+    # This class centralizes the authentication logic for connecting to Google
+    # APIs. It uses service account credentials passed via a configuration hash
+    # and always impersonates a domain administrator to perform actions.
+    class Base
+      attr_reader :config, :credentials
+
+      # Initializes the service.
+      def initialize(config, scope:)
+        @config = config
+        @credentials = authenticate(scope)
+      end
+
+      private
+
+      # Authenticates using service account credentials and impersonates an admin user.
+      def authenticate(scope)
+        authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+          json_key_io: File.open(config[:keyfile_path]),
+          scope: scope
+        )
+
+        auth_as_admin = authorizer.dup
+        auth_as_admin.sub = config[:admin_email]
+        auth_as_admin.fetch_access_token!
+
+        auth_as_admin
+      end
+
+      # This method MUST be implemented by any child class.
+      def build_service
+        raise NotImplementedError, 'Subclasses must implement the #build_service method'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR introduces a reusable base service (Service::GoogleWorkSpace::Base) that centralizes and manages authentication with Google Workspace APIs. The class is designed to be extended by other specific services (like Meet, Drive, etc.), ensuring a single, consistent, and easy-to-maintain authentication point.

The implementation uses a service account and always performs impersonation of an admin user, which is the required flow for accessing organization-wide data.

Fixes #166 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
