### PR TITLE
Relate Calendar Attendees to People table

### DIFF
--- a/db/warehouse_migrations/20250723105602_update_calendar_event_attendees_relation.rb
+++ b/db/warehouse_migrations/20250723105602_update_calendar_event_attendees_relation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:calendar_event_attendees) do
+      add_foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :set_null
+    end
+  end
+
+  down do
+    alter_table(:calendar_event_attendees) do
+      drop_column :person_id
+    end
+  end
+end

--- a/db/warehouse_migrations/20250723105602_update_calendar_event_attendees_relation.rb
+++ b/db/warehouse_migrations/20250723105602_update_calendar_event_attendees_relation.rb
@@ -4,12 +4,14 @@ Sequel.migration do
   up do
     alter_table(:calendar_event_attendees) do
       add_foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :set_null
+      drop_column :email
     end
   end
 
   down do
     alter_table(:calendar_event_attendees) do
       drop_column :person_id
+      add_column :email, String, size: 255, null: false
     end
   end
 end

--- a/spec/services/postgres/calendar_event_attendee_spec.rb
+++ b/spec/services/postgres/calendar_event_attendee_spec.rb
@@ -3,10 +3,9 @@
 require 'sequel'
 require 'rspec'
 require_relative '../../../src/services/postgres/base'
-require_relative '../../../src/services/postgres/calendar_event'
 require_relative '../../../src/services/postgres/calendar_event_attendee'
+require_relative '../../../src/services/postgres/calendar_event'
 require_relative '../../../src/services/postgres/person'
-
 require_relative 'test_db_helpers'
 
 RSpec.describe Services::Postgres::CalendarEventAttendee do
@@ -14,18 +13,17 @@ RSpec.describe Services::Postgres::CalendarEventAttendee do
 
   let(:db) { Sequel.sqlite }
   let(:config) { { adapter: 'sqlite', database: ':memory:' } }
+
   let(:service) { described_class.new(config) }
-  let(:event_service) { Services::Postgres::CalendarEvent.new(config) }
   let(:person_service) { Services::Postgres::Person.new(config) }
+  let(:calendar_event_service) { Services::Postgres::CalendarEvent.new(config) }
 
   before(:each) do
-    # Drop tables in reverse order of creation
     db.drop_table?(:calendar_event_attendees)
     db.drop_table?(:calendar_events)
     db.drop_table?(:persons)
     db.drop_table?(:domains)
 
-    # Create tables
     create_domains_table(db)
     create_persons_table(db)
     create_calendar_events_table(db)
@@ -34,124 +32,136 @@ RSpec.describe Services::Postgres::CalendarEventAttendee do
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end
 
-  describe '#insert' do
-    let!(:event_id) do
-      event_service.insert(
-        external_calendar_event_id: 'evt-1',
-        summary: 'Test Event',
-        duration_minutes: 60,
-        start_time: Time.now,
-        end_time: Time.now + 3600,
-        creation_timestamp: Time.now
-      )
-    end
+  # Datos de prueba
+  let!(:person_id) do
+    person_service.insert(
+      external_person_id: 'p-1',
+      full_name: 'Test Person',
+      email_address: 'test@example.com'
+    )
+  end
 
-    it 'creates a new attendee and resolves the calendar_event_id' do
+  let!(:calendar_event_id) do
+    calendar_event_service.insert(
+      external_calendar_event_id: 'evt-1',
+      summary: 'Test Event',
+      duration_minutes: 60,
+      start_time: Time.now,
+      end_time: Time.now + 3600,
+      creation_timestamp: Time.now
+    )
+  end
+
+  describe '#insert' do
+    it 'creates a new attendee by resolving email to person_id' do
       params = {
-        external_calendar_event_id: 'evt-1',
-        email: 'test@example.com',
+        calendar_event_id: calendar_event_id,
+        email_address: 'test@example.com',
         response_status: 'accepted'
       }
-      id = service.insert(params)
-      attendee = service.find(id)
 
-      expect(attendee[:calendar_event_id]).to eq(event_id)
-      expect(attendee[:email]).to eq('test@example.com')
+      attendee_id = service.insert(params)
+      attendee = service.find(attendee_id)
+
+      expect(attendee).not_to be_nil
+      expect(attendee[:person_id]).to eq(person_id)
+      expect(attendee[:calendar_event_id]).to eq(calendar_event_id)
       expect(attendee[:response_status]).to eq('accepted')
-    end
-
-    context 'with person association' do
-      let!(:person_id) do
-        person_service.insert(
-          external_person_id: 'ext-john',
-          full_name: 'John Doe',
-          email_address: 'john.doe@example.com'
-        )
-      end
-
-      it 'assigns person_id if the attendee email exists in the people table' do
-        params = {
-          external_calendar_event_id: 'evt-1',
-          email: 'john.doe@example.com', # Email que coincide con una persona existente
-          response_status: 'accepted'
-        }
-        id = service.insert(params)
-        attendee = service.find(id)
-
-        expect(attendee[:person_id]).to eq(person_id)
-      end
-
-      it 'leaves person_id as nil if the attendee email does not exist' do
-        params = {
-          external_calendar_event_id: 'evt-1',
-          email: 'unknown@example.com', # Email que no existe en la tabla people
-          response_status: 'needsAction'
-        }
-        id = service.insert(params)
-        attendee = service.find(id)
-
-        expect(attendee[:person_id]).to be_nil
-      end
     end
   end
 
   describe '#update' do
-    let(:attendee_id) do
-      event_id = event_service.insert(external_calendar_event_id: 'evt-2', summary: 'Event 2', duration_minutes: 30,
-                                      start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
-      service.insert(calendar_event_id: event_id, email: 'attendee@example.com', response_status: 'tentative')
+    let!(:attendee_id) do
+      service.insert(
+        calendar_event_id: calendar_event_id,
+        person_id: person_id,
+        response_status: 'accepted'
+      )
     end
 
-    it 'updates an attendee by ID' do
+    let!(:new_person_id) do
+      person_service.insert(
+        external_person_id: 'p-2',
+        full_name: 'New Person',
+        email_address: 'new@example.com'
+      )
+    end
+
+    it 'updates the response_status of an attendee' do
       service.update(attendee_id, { response_status: 'declined' })
-      updated = service.find(attendee_id)
-      expect(updated[:response_status]).to eq('declined')
+      updated_attendee = service.find(attendee_id)
+      expect(updated_attendee[:response_status]).to eq('declined')
     end
+
+    it 'updates the person associated with an attendee using email' do
+      service.update(attendee_id, { email_address: 'new@example.com' })
+      updated_attendee = service.find(attendee_id)
+      expect(updated_attendee[:person_id]).to eq(new_person_id)
+    end
+
     it 'raises an error if no ID is provided' do
-      expect { service.update(nil, { response_status: 'accepted' }) }.to raise_error(ArgumentError)
-    end
-
-    context 'with person association' do
-      let!(:person_id) do
-        person_service.insert(
-          external_person_id: 'ext-jane',
-          full_name: 'Jane Doe',
-          email_address: 'jane.doe@example.com'
-        )
-      end
-
-      it 'assigns person_id on update when email is changed to match a person' do
-        # Se actualiza el email para que coincida con una persona existente
-        service.update(attendee_id, { email: 'jane.doe@example.com' })
-        updated = service.find(attendee_id)
-
-        expect(updated[:person_id]).to eq(person_id)
-      end
+      expect { service.update(nil, { response_status: 'tentative' }) }.to raise_error(ArgumentError)
     end
   end
 
   describe '#delete' do
     it 'deletes an attendee by ID' do
-      event_id = event_service.insert(external_calendar_event_id: 'evt-3', summary: 'Event 3', duration_minutes: 15,
-                                      start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
-      id = service.insert(calendar_event_id: event_id, email: 'delete@example.com', response_status: 'accepted')
+      attendee_id = service.insert(
+        calendar_event_id: calendar_event_id,
+        person_id: person_id,
+        response_status: 'accepted'
+      )
 
-      expect { service.delete(id) }.to change { service.query.size }.by(-1)
-      expect(service.find(id)).to be_nil
+      expect(service.find(attendee_id)).not_to be_nil
+      expect { service.delete(attendee_id) }.to change { service.query.size }.by(-1)
+      expect(service.find(attendee_id)).to be_nil
+    end
+  end
+
+  describe '#find' do
+    it 'finds an attendee by ID' do
+      attendee_id = service.insert(
+        calendar_event_id: calendar_event_id,
+        person_id: person_id,
+        response_status: 'needsAction'
+      )
+
+      found_attendee = service.find(attendee_id)
+
+      expect(found_attendee[:id]).to eq(attendee_id)
+      expect(found_attendee[:person_id]).to eq(person_id)
     end
   end
 
   describe '#query' do
     before do
-      event_id = event_service.insert(external_calendar_event_id: 'evt-4', summary: 'Event 4', duration_minutes: 10,
-                                      start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
-      service.insert(calendar_event_id: event_id, email: 'query@example.com', response_status: 'accepted')
+      other_person_id = person_service.insert(
+        external_person_id: 'p-other',
+        full_name: 'Other',
+        email_address: 'other@example.com'
+      )
+      other_event_id = calendar_event_service.insert(
+        external_calendar_event_id: 'evt-other',
+        summary: 'Other Event',
+        duration_minutes: 60,
+        start_time: Time.now,
+        end_time: Time.now + 3600,
+        creation_timestamp: Time.now
+      )
+
+      service.insert(calendar_event_id: calendar_event_id, person_id: person_id, response_status: 'accepted')
+      service.insert(calendar_event_id: calendar_event_id, person_id: other_person_id, response_status: 'declined')
+      service.insert(calendar_event_id: other_event_id, person_id: person_id, response_status: 'tentative')
     end
 
-    it 'queries attendees by condition' do
-      results = service.query(response_status: 'accepted')
-      expect(results.size).to eq(1)
-      expect(results.first[:email]).to eq('query@example.com')
+    it 'queries attendees by a condition' do
+      results = service.query(calendar_event_id: calendar_event_id)
+      expect(results.size).to eq(2)
+    end
+
+    it 'returns all attendees with empty conditions' do
+      results = service.query
+      expect(results.size).to eq(3)
     end
   end
 end

--- a/spec/services/postgres/calendar_event_attendee_spec.rb
+++ b/spec/services/postgres/calendar_event_attendee_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Services::Postgres::CalendarEventAttendee do
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end
 
-  # Datos de prueba
+  # Test data
   let!(:person_id) do
     person_service.insert(
       external_person_id: 'p-1',

--- a/spec/services/postgres/calendar_event_spec.rb
+++ b/spec/services/postgres/calendar_event_spec.rb
@@ -4,6 +4,8 @@ require 'sequel'
 require 'rspec'
 require_relative '../../../src/services/postgres/base'
 require_relative '../../../src/services/postgres/calendar_event'
+require_relative '../../../src/services/postgres/calendar_event_attendee'
+require_relative '../../../src/services/postgres/person'
 require_relative 'test_db_helpers'
 
 RSpec.describe Services::Postgres::CalendarEvent do
@@ -12,34 +14,89 @@ RSpec.describe Services::Postgres::CalendarEvent do
   let(:db) { Sequel.sqlite }
   let(:config) { { adapter: 'sqlite', database: ':memory:' } }
   let(:service) { described_class.new(config) }
+  let(:attendee_service) { Services::Postgres::CalendarEventAttendee.new(service.db) }
+  let(:person_service) { Services::Postgres::Person.new(service.db) }
 
   before(:each) do
+    db.drop_table?(:calendar_event_attendees)
+    db.drop_table?(:persons)
+    db.drop_table?(:domains)
     db.drop_table?(:calendar_events)
+
     create_calendar_events_table(db)
+    create_calendar_event_attendees_table(db)
+    create_persons_table(db)
+    create_domains_table(db)
 
     allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
   end
 
   describe '#insert' do
     it 'creates a new calendar_event and returns its ID' do
+      person_one_id = person_service.insert(external_person_id: 'ext-p-1',
+                                            full_name: 'Jane Doe',
+                                            email_address: 'jane@example.com')
+      person_two_id = person_service.insert(external_person_id: 'ext-p-2',
+                                            full_name: 'Other',
+                                            email_address: 'other@example.com')
+
       params = {
         external_calendar_event_id: 'evt-123',
         summary: 'Test Event',
         duration_minutes: 60,
         start_time: Time.now,
         end_time: Time.now + 3600,
-        creation_timestamp: Time.now - 86_400
+        creation_timestamp: Time.now - 86_400,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' },
+          { email_address: 'other@example.com', response_status: 'declined' }
+        ]
       }
       id = service.insert(params)
       event = service.find(id)
+      attendees = attendee_service.query(calendar_event_id: id)
 
       expect(event[:summary]).to eq('Test Event')
       expect(event[:external_calendar_event_id]).to eq('evt-123')
       expect(event[:duration_minutes]).to eq(60)
+
+      expect(attendees.size).to eq(2)
+
+      attendee_person_ids = attendees.map { |a| a[:person_id] }
+      expect(attendee_person_ids).to contain_exactly(person_one_id, person_two_id)
+
+      emails = attendee_person_ids.map do |pid|
+        person_service.find(pid)[:email_address]
+      end
+      expect(emails).to contain_exactly('jane@example.com', 'other@example.com')
     end
   end
 
   describe '#update' do
+    let(:person_one_id) do
+      person_service.insert(
+        external_person_id: 'ext-p-1',
+        full_name: 'Jane Doe',
+        email_address: 'jane@example.com'
+      )
+    end
+
+    let(:person_two_id) do
+      person_service.insert(
+        external_person_id: 'ext-p-2',
+        full_name: 'Other',
+        email_address: 'other@example.com'
+      )
+    end
+
+    let!(:person_three_id) do
+      person_service.insert(
+        external_person_id: 'ext-p-3',
+        full_name: 'New Person',
+        email_address: 'new@example.com'
+      )
+    end
+
     let(:event_id) do
       service.insert(
         external_calendar_event_id: 'evt-to-update',
@@ -47,16 +104,35 @@ RSpec.describe Services::Postgres::CalendarEvent do
         duration_minutes: 30,
         start_time: Time.now,
         end_time: Time.now + 1800,
-        creation_timestamp: Time.now - 86_400
+        creation_timestamp: Time.now - 86_400,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' },
+          { email_address: 'other@example.com', response_status: 'declined' }
+        ]
       )
     end
 
-    it 'updates a calendar_event by ID' do
-      service.update(event_id, { summary: 'Updated Summary', duration_minutes: 45 })
+    it 'updates a calendar_event by ID including attendees' do
+      service.update(
+        event_id,
+        {
+          summary: 'Updated Summary',
+          duration_minutes: 45,
+          attendees: [
+            { email_address: 'new@example.com', response_status: 'tentative' }
+          ]
+        }
+      )
       updated = service.find(event_id)
+      attendees = attendee_service.query(calendar_event_id: event_id)
 
       expect(updated[:summary]).to eq('Updated Summary')
       expect(updated[:duration_minutes]).to eq(45)
+
+      expect(attendees.size).to eq(1)
+      expect(attendees.first[:response_status]).to eq('tentative')
+
+      expect(attendees.first[:person_id]).to eq(person_three_id)
     end
 
     it 'raises an error if no ID is provided' do
@@ -65,32 +141,86 @@ RSpec.describe Services::Postgres::CalendarEvent do
   end
 
   describe '#delete' do
-    it 'deletes a calendar_event by ID' do
-      id = service.insert(external_calendar_event_id: 'evt-to-delete', summary: 'To Delete', duration_minutes: 15,
-                          start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+    it 'deletes a calendar_event by ID and its attendees' do
+      person_service.insert(external_person_id: 'ext-p-1', full_name: 'Jane Doe', email_address: 'jane@example.com')
+
+      id = service.insert(
+        external_calendar_event_id: 'evt-to-delete',
+        summary: 'To Delete',
+        duration_minutes: 15,
+        start_time: Time.now,
+        end_time: Time.now,
+        creation_timestamp: Time.now,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' }
+        ]
+      )
 
       expect { service.delete(id) }.to change { service.query.size }.by(-1)
+
+      attendees = attendee_service.query(calendar_event_id: id)
+      expect(attendees).to be_empty
+
       expect(service.find(id)).to be_nil
     end
   end
 
   describe '#find' do
-    it 'finds a calendar_event by ID' do
-      id = service.insert(external_calendar_event_id: 'evt-to-find', summary: 'Find Me', duration_minutes: 10,
-                          start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+    it 'finds a calendar_event by ID and returns attendees' do
+      person_service.insert(external_person_id: 'ext-p-1', full_name: 'Jane Doe', email_address: 'jane@example.com')
+      person_service.insert(external_person_id: 'ext-p-2', full_name: 'Other', email_address: 'other@example.com')
+
+      id = service.insert(
+        external_calendar_event_id: 'evt-to-find',
+        summary: 'Find Me',
+        duration_minutes: 10,
+        start_time: Time.now,
+        end_time: Time.now,
+        creation_timestamp: Time.now,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' },
+          { email_address: 'other@example.com', response_status: 'declined' }
+        ]
+      )
       found = service.find(id)
+      attendees = attendee_service.query(calendar_event_id: id)
 
       expect(found[:id]).to eq(id)
       expect(found[:summary]).to eq('Find Me')
+      expect(attendees.size).to eq(2)
+
+      attendee_emails = attendees.map { |a| person_service.find(a[:person_id])[:email_address] }
+      expect(attendee_emails).to contain_exactly('jane@example.com', 'other@example.com')
     end
   end
 
   describe '#query' do
     before do
-      service.insert(external_calendar_event_id: 'evt-query-1', summary: 'Query Me', duration_minutes: 5,
-                     start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
-      service.insert(external_calendar_event_id: 'evt-query-2', summary: 'Another Event', duration_minutes: 25,
-                     start_time: Time.now, end_time: Time.now, creation_timestamp: Time.now)
+      person_service.insert(external_person_id: 'ext-p-1', full_name: 'Jane Doe', email_address: 'jane@example.com')
+      person_service.insert(external_person_id: 'ext-p-2', full_name: 'Other', email_address: 'other@example.com')
+
+      service.insert(
+        external_calendar_event_id: 'evt-query-1',
+        summary: 'Query Me',
+        duration_minutes: 5,
+        start_time: Time.now,
+        end_time: Time.now,
+        creation_timestamp: Time.now,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' }
+        ]
+      )
+      service.insert(
+        external_calendar_event_id: 'evt-query-2',
+        summary: 'Another Event',
+        duration_minutes: 25,
+        start_time: Time.now,
+        end_time: Time.now,
+        creation_timestamp: Time.now,
+        attendees: [
+          { email_address: 'other@example.com', response_status: 'accepted' }
+        ]
+      )
     end
 
     it 'queries calendar_events by condition' do

--- a/spec/services/postgres/calendar_event_spec.rb
+++ b/spec/services/postgres/calendar_event_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe Services::Postgres::CalendarEvent do
       end
       expect(emails).to contain_exactly('jane@example.com', 'other@example.com')
     end
+
+    it 'handles attendees with unknown email addresses gracefully' do
+      person_service.insert(
+        external_person_id: 'ext-p-1',
+        full_name: 'Jane Doe',
+        email_address: 'jane@example.com'
+      )
+
+      params = {
+        external_calendar_event_id: 'evt-123',
+        summary: 'Test Event',
+        duration_minutes: 60,
+        start_time: Time.now,
+        end_time: Time.now + 3600,
+        creation_timestamp: Time.now - 86_400,
+        attendees: [
+          { email_address: 'jane@example.com', response_status: 'accepted' },
+          { email_address: 'unknown@example.com', response_status: 'declined' }
+        ]
+      }
+      # Should either skip unknown attendees or handle gracefully
+      expect { service.insert(params) }.not_to raise_error
+    end
   end
 
   describe '#update' do

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -240,7 +240,6 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
       primary_key :id
       foreign_key :calendar_event_id, :calendar_events, type: :uuid, null: false, on_delete: :cascade
       foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :cascade
-      String :email, size: 255, null: false
       String :response_status, size: 50, null: false
     end
   end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -239,6 +239,7 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
     db.create_table(:calendar_event_attendees) do
       primary_key :id
       foreign_key :calendar_event_id, :calendar_events, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :cascade
       String :email, size: 255, null: false
       String :response_status, size: 50, null: false
     end

--- a/src/services/postgres/calendar_event_attendee.rb
+++ b/src/services/postgres/calendar_event_attendee.rb
@@ -2,6 +2,7 @@
 
 require_relative 'base'
 require_relative 'calendar_event'
+require_relative 'person'
 
 module Services
   module Postgres
@@ -10,7 +11,7 @@ module Services
     #
     # Provides CRUD operations for the 'calendar_event_attendees' table.
     class CalendarEventAttendee < Services::Postgres::Base
-      ATTRIBUTES = %i[calendar_event_id email response_status].freeze
+      ATTRIBUTES = %i[calendar_event_id person_id email response_status].freeze
 
       TABLE = :calendar_event_attendees
 
@@ -20,6 +21,8 @@ module Services
 
       def insert(params)
         assign_relations(params)
+        assign_person_from_email(params)
+
         transaction { insert_item(TABLE, params) }
       rescue StandardError => e
         handle_error(e)
@@ -29,6 +32,8 @@ module Services
         raise ArgumentError, 'Calendar event attendee id is required to update' unless id
 
         assign_relations(params)
+        assign_person_from_email(params)
+
         transaction { update_item(TABLE, id, params) }
       rescue StandardError => e
         handle_error(e)
@@ -53,6 +58,15 @@ module Services
       end
 
       private
+
+      def assign_person_from_email(params)
+        return unless params[:email]
+
+        person_service = Services::Postgres::Person.new(db)
+        person = person_service.query(email_address: params[:email]).first
+
+        params[:person_id] = person[:id] if person
+      end
 
       def handle_error(error)
         puts "[CalendarEventAttendee Service ERROR] #{error.class}: #{error.message}"


### PR DESCRIPTION
## Description

This PR introduces a direct relationship between the CalendarAttendee and People entities by adding a person_id foreign key to the calendar_attendees table.

Currently, the CalendarAttendee entity tracks attendees by email. Since most are internal employees, this change establishes a direct link to the people table. The CalendarEventAttendee service has been updated to automatically look up a person by their email_address and populate the person_id field upon insertion or update.

Fixes #171 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar event attendees can now be linked to a person entity, replacing the previous email-based identification.
  * Calendar events support managing associated attendees during creation and updates, including adding, updating, and removing attendees.

* **Bug Fixes**
  * Improved accuracy in associating calendar event attendees with persons when emails match, both during creation and updates.

* **Tests**
  * Expanded test coverage to verify correct linkage between attendees and persons, ensuring the new association works as expected.
  * Added comprehensive tests for attendee lifecycle operations linked to calendar events and persons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->