### PR TITLE
Fix date problem in fetch worklogs bot

### DIFF
--- a/src/implementations/fetch_records_from_work_logs.rb
+++ b/src/implementations/fetch_records_from_work_logs.rb
@@ -43,9 +43,11 @@ module Implementation
   class FetchRecordsFromWorkLogs < Bas::Bot::Base
     RECORDS_PER_PAGE = 100
     PAGE_SIZE = 100
+    DEFAULT_START_DATE = Date.new(2023, 7, 10)
 
     def process
-      start_date = (read_response.inserted_at || Date.new(2023, 7, 10)).to_s
+      start_date = determine_start_date
+
       logs = fetch_all_logs(start_date)
       normalized_content = normalize_response(logs)
 
@@ -70,6 +72,12 @@ module Implementation
     end
 
     private
+
+    def determine_start_date
+      last_run_timestamp = read_response&.inserted_at
+      date_object = last_run_timestamp ? DateTime.parse(last_run_timestamp.to_s) : DEFAULT_START_DATE
+      date_object.strftime('%Y-%m-%d')
+    end
 
     def fetch_all_logs(start_date)
       all_logs = []


### PR DESCRIPTION
## Description

This PR addresses a recurring failure in the `FetchWorklogs` bot deployed in the staging environment, where requests to the WorkLogs API were returning `500 Internal Server Error`. 

After investigation, the root cause was identified as a **type mismatch in the `inserted_at` field** obtained from the `read_response`. In some cases, the value was not properly to the API request.

Fixes #182 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of start date selection for work log records, ensuring consistent and reliable date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->