### PR TITLE
Add postgres service for documents activity logs

### DIFF
--- a/db/warehouse_migrations/20250731140514_create_document_activity_logs_table.rb
+++ b/db/warehouse_migrations/20250731140514_create_document_activity_logs_table.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:document_activity_logs) do
+      uuid :id, primary_key: true, default: Sequel.lit('gen_random_uuid()')
+      foreign_key :document_id, :documents, type: :uuid, null: false
+      foreign_key :person_id, :persons, type: :uuid, null: true
+      String :action, size: 255, null: false
+      jsonb :details, null: false, default: '{}'
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
+  down do
+    drop_table(:document_activity_logs)
+  end
+end

--- a/spec/services/postgres/document_activity_log_spec.rb
+++ b/spec/services/postgres/document_activity_log_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'rspec'
+require_relative '../../../src/services/postgres/base'
+require_relative '../../../src/services/postgres/document_activity_log'
+require_relative '../../../src/services/postgres/domain'
+require_relative 'test_db_helpers'
+
+RSpec.describe Services::Postgres::DocumentActivityLog do
+  include TestDBHelpers
+
+  # Use an in-memory SQLite database for testing
+  let(:db) { Sequel.sqlite }
+  let(:config) do
+    {
+      adapter: 'sqlite',
+      database: ':memory:'
+    }
+  end
+  let(:service) { described_class.new(config) }
+  let(:document_service) { Services::Postgres::Document.new(config) }
+  let(:person_service) { Services::Postgres::Person.new(config) }
+  let(:domain_service) { Services::Postgres::Domain.new(config) }
+
+  # Create the table structure before each test
+  before(:each) do
+    db.drop_table?(:document_activity_logs)
+    db.drop_table?(:documents)
+    db.drop_table?(:persons)
+    db.drop_table?(:domains)
+
+    create_domains_table(db)
+    create_documents_table(db)
+    create_persons_table(db)
+    create_document_activity_logs_table(db)
+
+    allow_any_instance_of(Services::Postgres::Base).to receive(:establish_connection).and_return(db)
+  end
+
+  let(:domain_id) do
+    domain_service.insert(external_domain_id: 'test-domain', name: 'Test Domain')
+  end
+
+  let(:document_id) do
+    document_service.insert(external_document_id: 'ext-doc-1', name: 'ops-doc',
+                            external_domain_id: domain_id)
+  end
+  let(:person_id) do
+    person_service.insert(external_person_id: 'person-1', full_name: 'John Doe',
+                          email_address: 'john@example.com', external_domain_id: domain_id)
+  end
+
+  describe '#insert' do
+    it 'creates a new document activity log and returns its ID and assigns foreign keys' do
+      params = { document_id: document_id, person_id: person_id, action: 'create',
+                 details: '{"date": "2025-01-01"}' }
+      id = service.insert(params)
+      document_activity_log = service.find(id)
+      expect(document_activity_log[:document_id]).to eq(document_id)
+      expect(document_activity_log[:person_id]).to eq(person_id)
+      expect(document_activity_log[:action]).to eq('create')
+      expect(document_activity_log[:details]).to eq('{"date": "2025-01-01"}')
+    end
+
+    it 'does not assign person_id if it is not provided' do
+      params = { document_id: document_id, action: 'create', details: '{"date": "2025-01-01"}' }
+      id = service.insert(params)
+      document_activity_log = service.find(id)
+      expect(document_activity_log[:document_id]).to eq(document_id)
+      expect(document_activity_log[:person_id]).to be_nil
+    end
+  end
+
+  describe '#update' do
+    it 'updates a document activity log by ID' do
+      id = service.insert(document_id: document_id, person_id: person_id, action: 'create',
+                          details: '{"date": "2025-01-01"}')
+      service.update(id, { action: 'update', details: '{"date": "2025-01-02"}' })
+      document_activity_log = service.find(id)
+      expect(document_activity_log[:action]).to eq('update')
+      expect(document_activity_log[:details]).to eq('{"date": "2025-01-02"}')
+    end
+
+    it 'reassigns person_id on update with external_person_id' do
+      person_id2 = person_service.insert(external_person_id: 'person-2', full_name: 'Jane Doe',
+                                         email_address: 'jane@example.com', external_domain_id: domain_id)
+      id = service.insert(document_id: document_id, person_id: person_id, action: 'create',
+                          details: '{"date": "2025-01-01"}')
+      service.update(id, { person_id: person_id2 })
+      updated_document_activity_log = service.find(id)
+      expect(updated_document_activity_log[:person_id]).to eq(person_id2)
+    end
+
+    it 'raises error if no ID is provided' do
+      expect { service.update(nil, name: 'No ID') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a document activity log by ID' do
+      id = service.insert(document_id: document_id, person_id: person_id, action: 'create',
+                          details: '{"date": "2025-01-01"}')
+      expect { service.delete(id) }.to change { service.query.size }.by(-1)
+      expect(service.find(id)).to be_nil
+    end
+  end
+
+  describe '#find' do
+    it 'finds a document activity log by ID' do
+      id = service.insert(document_id: document_id, person_id: person_id, action: 'create',
+                          details: '{"date": "2025-01-01"}')
+      document_activity_log = service.find(id)
+      expect(document_activity_log[:id]).to eq(id)
+      expect(document_activity_log[:document_id]).to eq(document_id)
+      expect(document_activity_log[:person_id]).to eq(person_id)
+      expect(document_activity_log[:action]).to eq('create')
+      expect(document_activity_log[:details]).to eq('{"date": "2025-01-01"}')
+    end
+  end
+
+  describe '#query' do
+    let!(:record_1_id) do
+      service.insert(document_id: document_id, person_id: person_id, action: 'create',
+                     details: '{"date": "2025-01-01"}')
+    end
+
+    let!(:record_2_id) do
+      service.insert(document_id: document_id, person_id: person_id, action: 'update',
+                     details: '{"date": "2025-01-02"}')
+    end
+
+    it 'queries document activity logs by condition' do
+      results = service.query(action: 'create')
+      expect(results.map { |a| a[:id] }).to include(record_1_id)
+      expect(results.map { |a| a[:id] }).not_to include(record_2_id)
+    end
+
+    it 'returns all document activity logs with empty conditions' do
+      expect(service.query.size).to eq(2)
+      expect(service.query.map { |a| a[:id] }).to match_array([record_1_id, record_2_id])
+    end
+  end
+end

--- a/spec/services/postgres/test_db_helpers.rb
+++ b/spec/services/postgres/test_db_helpers.rb
@@ -97,6 +97,18 @@ module TestDBHelpers # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  def create_document_activity_logs_table(db)
+    db.create_table(:document_activity_logs) do
+      primary_key :id
+      foreign_key :document_id, :documents, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :person_id, :persons, type: :uuid, null: true, on_delete: :cascade
+      String :action, size: 255, null: false
+      jsonb :details, null: false, default: '{}'
+      DateTime :created_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+      DateTime :updated_at, default: Sequel.lit('CURRENT_TIMESTAMP')
+    end
+  end
+
   def create_weekly_scopes_table(db) # rubocop:disable Metrics/MethodLength
     db.create_table(:weekly_scopes) do
       primary_key :id

--- a/src/services/postgres/document_activity_log.rb
+++ b/src/services/postgres/document_activity_log.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'document'
+require_relative 'person'
+
+module Services
+  module Postgres
+    ##
+    # DocumentActivityLog Service for PostgreSQL
+    #
+    # Provides CRUD operations for the 'document_activity_logs' table using the Base service.
+    class DocumentActivityLog < Services::Postgres::Base
+      ATTRIBUTES = %i[document_id person_id action details].freeze
+      TABLE = :document_activity_logs
+
+      RELATIONS = [
+        { service: Document, external: :external_document_id, internal: :document_id },
+        { service: Person, external: :external_person_id, internal: :person_id }
+      ].freeze
+
+      def insert(params)
+        assign_relations(params)
+        transaction { insert_item(TABLE, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def update(id, params)
+        raise ArgumentError, 'DocumentActivityLog id is required to update' unless id
+
+        assign_relations(params)
+        transaction { update_item(TABLE, id, params) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def delete(id)
+        transaction { delete_item(TABLE, id) }
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      def find(id)
+        find_item(TABLE, id)
+      end
+
+      def query(conditions = {})
+        query_item(TABLE, conditions)
+      end
+
+      private
+
+      def handle_error(error)
+        puts "[DocumentActivityLog Service ERROR] #{error.class}: #{error.message}"
+        raise error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Create the service class to log document activities. It adds a document_activity_logs table to the warehouse, a DocumentActivityLog service to interact with it, and corresponding tests. This will allow tracking actions performed on documents, such as creation and updates.

Closes #190

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for tracking document activity logs, including actions, details, and associations with documents and persons.
  * Added the ability to view, create, update, and delete document activity logs.

* **Tests**
  * Implemented comprehensive tests to ensure reliability of document activity log operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->