### PR TITLE
Implement the Fetch Next Week PTOs Webhook.

### DIFF
--- a/src/use_cases_execution/pto_next_week/Google_nw_pto_script.js
+++ b/src/use_cases_execution/pto_next_week/Google_nw_pto_script.js
@@ -1,0 +1,99 @@
+function sendNextWeekToWebhook() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const rows = data.slice(1);
+
+  const { monday, sunday } = getNextWeekRange();
+
+  const ptos = rows
+    .map(row => Object.fromEntries(headers.map((h, i) => [h, row[i]])))
+    .filter(entry => {
+      const start = toDateOnly(entry['StartDateTime']);
+      const end = toDateOnly(entry['EndDateTime']);
+      const dayValue = entry['Day'];
+      const isPTO = entry['Category']?.includes('PTO');
+
+      const startsInRange = start >= monday && start <= sunday;
+      const endsInRange = end >= monday && end <= sunday;
+      const coversRange = start <= monday && end >= sunday;
+
+      return (
+        (startsInRange || endsInRange || coversRange) &&
+        isPTO &&
+        dayValue === 'Full Day'
+      );
+    })
+    .map(entry => {
+      const name = entry['Person'] || 'Someone';
+      const start = toDateOnly(entry['StartDateTime']);
+      const end = toDateOnly(entry['EndDateTime']);
+      return formatMessage(name, start, end);
+    });
+
+  const url = PropertiesService.getScriptProperties().getProperty('WEBHOOK_URL_NW_PTO');
+  const token = PropertiesService.getScriptProperties().getProperty('WEBHOOK_TOKEN');
+  if (!url || ptos.length === 0) return;
+
+  const payload = JSON.stringify({ ptos });
+  console.log(ptos);
+
+  try {
+    const res = UrlFetchApp.fetch(url, {
+      method: 'post',
+      contentType: 'application/json',
+      payload,
+      muteHttpExceptions: true,
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    console.log('Status:', res.getResponseCode());
+    console.log('Body:', res.getContentText());
+  } catch (err) {
+    console.error('Error:', err);
+  }
+}
+
+function getNextWeekRange() {
+  const today = new Date();
+  const day = today.getDay();
+  const daysUntilNextMonday = day === 0 ? 1 : 8 - day;
+
+  const monday = new Date(today);
+  monday.setDate(today.getDate() + daysUntilNextMonday);
+  monday.setHours(0, 0, 0, 0);
+
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  sunday.setHours(0, 0, 0, 0);
+
+  return { monday, sunday };
+}
+
+function toDateOnly(val) {
+  const date = new Date(val);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function formatDateString(date) {
+  return date.toISOString().split('T')[0];
+}
+
+function formatMessage(name, startDate, endDate) {
+  const startStr = formatDateString(startDate);
+  const endStr = formatDateString(endDate);
+  const returnStr = getNextWorkday(endDate);
+  return `${name} will not be working between ${startStr} and ${endStr}. And returns the ${returnStr}`;
+}
+
+function getNextWorkday(date) {
+  const next = new Date(date);
+  switch (next.getDay()) {
+    case 5: next.setDate(next.getDate() + 3); break; // Friday → Monday
+    case 6: next.setDate(next.getDate() + 2); break; // Saturday → Monday
+    default: next.setDate(next.getDate() + 1); break;
+  }
+  return formatDateString(next);
+}

--- a/src/use_cases_execution/pto_next_week/fetch_next_week_pto_from_google_for_workspace.rb
+++ b/src/use_cases_execution/pto_next_week/fetch_next_week_pto_from_google_for_workspace.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'sinatra/base'
+require 'json'
+require 'bas/shared_storage/postgres'
+require_relative 'config'
+
+module Routes
+  class PtoNextWeek < Sinatra::Base
+    write_options = {
+      connection: Config::CONNECTION,
+      db_table: 'pto',
+      tag: 'FetchNextWeekPtosFromGoogleForWorkspace'
+    }
+
+    TOKEN = ENV.fetch('WEBHOOK_TOKEN')
+
+    post '/pto-next-week' do
+      content_type :json
+
+      auth_header = request.env['HTTP_AUTHORIZATION']
+      if auth_header.nil? || !auth_header.start_with?('Bearer ')
+        halt 401, { error: 'Missing or invalid Authorization header' }.to_json
+      end
+
+      token = auth_header.split(' ').last
+      halt 403, { error: 'Forbidden: invalid token' }.to_json unless token == TOKEN
+
+      begin
+        request_body = request.body.read
+        halt 400, { error: 'Empty request body' }.to_json if request_body.strip.empty?
+
+        data = JSON.parse(request_body)
+        halt 400, { error: 'Invalid JSON format' }.to_json unless data.is_a?(Hash) && !data.empty?
+        halt 400, { error: 'Missing or invalid "ptos" array' }.to_json unless data['ptos'].is_a?(Array)
+      rescue StandardError
+        halt 400, { error: 'Invalid JSON format' }.to_json
+      end
+
+      # Write to storage
+      begin
+        shared_storage = Bas::SharedStorage::Postgres.new(write_options: write_options)
+        shared_storage.write(success: { ptos: data['ptos'] })
+      rescue StandardError => e
+        halt 500, { error: 'Internal Server Error', detail: e.message }.to_json
+      end
+
+      status 200
+      { message: 'PTOs stored successfully' }.to_json
+    end
+  end
+end

--- a/src/use_cases_execution/pto_next_week/fetch_next_week_pto_from_google_for_workspace.rb
+++ b/src/use_cases_execution/pto_next_week/fetch_next_week_pto_from_google_for_workspace.rb
@@ -6,6 +6,7 @@ require 'bas/shared_storage/postgres'
 require_relative 'config'
 
 module Routes
+  # Routes::PtoNextWeek defines the /pto-next-week endpoint that receives PTO data
   class PtoNextWeek < Sinatra::Base
     write_options = {
       connection: Config::CONNECTION,

--- a/src/use_cases_execution/pto_next_week/humanize_next_week_pto_workspace.rb
+++ b/src/use_cases_execution/pto_next_week/humanize_next_week_pto_workspace.rb
@@ -13,7 +13,7 @@ today = Time.at(utc_today, in: '-05:00').strftime('%F').to_s
 read_options = {
   connection: Config::CONNECTION,
   db_table: 'pto',
-  tag: 'FetchNextWeekPtosFromNotionForWorkspace'
+  tag: 'FetchNextWeekPtosFromGoogleForWorkspace'
 }
 
 write_options = {

--- a/src/use_cases_execution/use_cases_webserver/app.rb
+++ b/src/use_cases_execution/use_cases_webserver/app.rb
@@ -5,6 +5,7 @@ require_relative '../pto/fetch_pto_from_google_for_workspace'
 require_relative '../birthday/fetch_birthdays_from_google'
 require_relative '../warehouse/google_workspace/listen_to_google_docs_updates'
 require_relative '../warehouse/google_workspace/listen_to_google_calendar_updates'
+require_relative '../pto_next_week/fetch_next_week_pto_from_google_for_workspace'
 
 # The WebServer class defines the main Sinatra application responsible for
 # handling incoming webhooks from Google services.
@@ -18,6 +19,7 @@ class WebServer < Sinatra::Base
   use Routes::Birthdays
   use Routes::GoogleDocuments
   use Routes::CalendarEvents
+  use Routes::PtoNextWeek
 
   get('/') { 'OK' }
 end


### PR DESCRIPTION
## Description

This feature introduces a new Google Apps Script function sendNextWeekToWebhook, which collects PTO entries scheduled for the upcoming week from a Google Sheet and sends them to a designated webhook endpoint.


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [X] My changes generate no new warnings
