### PR TITLE
Add garbage collector to expired projects use case

### DIFF
--- a/src/use_cases_execution/expired_projects/garbage_collector.rb
+++ b/src/use_cases_execution/expired_projects/garbage_collector.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'json'
+require 'bas/shared_storage/postgres'
+require 'bas/shared_storage/default'
+
+require_relative '../../implementations/garbage_collector'
+require_relative 'config'
+
+# Configuration
+write_options = {
+  connection: Config::CONNECTION,
+  db_table: 'expired_projects',
+  tag: 'GarbageCollector'
+}
+
+options = {
+  connection: Config::CONNECTION,
+  db_table: 'expired_projects'
+}
+
+# Process bot
+begin
+  shared_storage_reader = Bas::SharedStorage::Default.new
+  shared_storage_writer = Bas::SharedStorage::Postgres.new({ write_options: })
+
+  Implementation::GarbageCollector.new(options, shared_storage_reader, shared_storage_writer).execute
+rescue StandardError => e
+  Logger.new($stdout).info(e.message)
+end

--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -126,7 +126,8 @@ module UseCasesExecution
     EXPIRED_PROJECTS_SCHEDULES = [
       { path: "#{__dir__}/expired_projects/fetch_expired_projects.rb", time: ['12:40'] },
       { path: "#{__dir__}/expired_projects/format_expired_projects.rb", time: ['12:50'] },
-      { path: "#{__dir__}/expired_projects/notify_expired_projects_in_workspace.rb", time: ['13:00'] }
+      { path: "#{__dir__}/expired_projects/notify_expired_projects_in_workspace.rb", time: ['13:00'] },
+      { path: "#{__dir__}/expired_projects/garbage_collector.rb", time: ['00:00'] }
     ].freeze
 
     GITHUB_NOTION_ISSUES_SYNC_SCHEDULES = [


### PR DESCRIPTION
## Description

This pull request adds a garbage collector to the **Expired Projects** use case.  
The garbage collector ensures that empty or irrelevant records are skipped when sending notifications, preventing the system from using the last non-empty message inappropriately.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  
- [ ] This change requires a documentation update  

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code 
- [x] My changes generate no new warnings  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced automated cleanup of expired projects, running nightly at 00:00.
* Bug Fixes
  * Upcoming birthday notifications now include only contacts whose birthday is exactly seven days from today (using the spreadsheet’s time zone), preventing extra notices from week-range matching.
* Chores
  * Added a schedule entry to run the expired projects cleanup task at 00:00.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->