### PR TITLE
Fix library import problem in kpi postgres service

### DIFF
--- a/src/services/postgres/kpi.rb
+++ b/src/services/postgres/kpi.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require_relative 'base'
-require_relative 'domain' # Added to manage the relationship
+require_relative 'domain'
+require_relative 'kpi_history'
 
 module Services
   module Postgres


### PR DESCRIPTION
## Description

This PR resolves the bug where KPI update operations were not being logged. The issue was caused by a missing import of the kpi_history postgres service within the kpi service's scope.

By adding the correct import, this change enables the kpi service to call the kpi_history service whenever a KPI is updated. This ensures that a corresponding log entry is created in the database, restoring full traceability for all modifications.

Fixes #209

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - KPI updates are now recorded as historical entries, enabling visibility into past KPI states where surfaced in the product.
- Bug Fixes
  - None.
- Documentation
  - None.
- Refactor
  - None.
- Style
  - None.
- Tests
  - None.
- Chores
  - Backend enhanced to retain change history for KPIs without altering existing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->