### PR TITLE
Migrate Key Results bot to Google Workspace

### DIFF
--- a/spec/use_cases_execution/google_workspace/listen_to_google_key_results_file_spec.rb
+++ b/spec/use_cases_execution/google_workspace/listen_to_google_key_results_file_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bas/shared_storage/postgres'
+require 'bas/shared_storage/default'
+
+# Adjust the path to your actual routes and formatter files
+require_relative '../../../src/use_cases_execution/warehouse/google_workspace/listen_to_google_key_results_file'
+require_relative '../../../src/utils/warehouse/google_workspace/key_results_format'
+
+RSpec.describe Routes::KeyResults do
+  include Rack::Test::Methods
+
+  def app
+    described_class.new({})
+  end
+
+  # Mocks for dependencies
+  let(:mocked_storage_writer) { instance_double(Bas::SharedStorage::Postgres, write: nil) }
+  let(:mocked_formatter_instance) { instance_double(Utils::Warehouse::GoogleWorkspace::KeyResultsFormatter) }
+  let(:formatted_result) { { external_key_result_id: 'some-uuid', okr: 'Test OKR' } }
+
+  # Test data mimicking the raw payload from the App Script
+  let(:raw_sheet_data) do
+    [
+      # Header Row
+      ['Objective', 'Owner', 'Key Result', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov',
+       'Dec', 'Target'],
+      # Data Row 1
+      ['OKR-1', 'Team A', 'Launch feature X', nil, nil, 10, 20, '-', nil, nil, nil, nil, nil, nil, nil, 100],
+      # Data Row 2
+      ['OKR-2', 'Team B', 'Improve performance', 5, 15, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 50]
+    ]
+  end
+
+  let(:valid_payload) do
+    { 'key_results_raw' => raw_sheet_data }
+  end
+
+  def post_key_results(payload)
+    post '/key_results', payload.to_json, { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  before do
+    # Mock the storage writer
+    allow(Bas::SharedStorage::Postgres).to receive(:new).and_return(mocked_storage_writer)
+
+    # Mock the formatter
+    allow(Utils::Warehouse::GoogleWorkspace::KeyResultsFormatter).to receive(:new).and_return(mocked_formatter_instance)
+    allow(mocked_formatter_instance).to receive(:format).and_return(formatted_result)
+
+    # Suppress logger output in tests
+    allow_any_instance_of(described_class).to receive(:logger).and_return(double('logger').as_null_object)
+  end
+
+  context 'POST /key_results' do
+    it 'returns 400 for empty request body' do
+      post '/key_results', '', { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Empty request body')
+    end
+
+    it 'returns 400 for invalid JSON' do
+      post '/key_results', '{not valid json}', { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Invalid JSON format')
+    end
+
+    it 'returns 400 for missing key_results_raw key' do
+      post_key_results({ 'wrong_key' => [] })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Missing or invalid "key_results_raw" array')
+    end
+
+    it 'returns 400 if key_results_raw is not an array' do
+      post_key_results({ 'key_results_raw' => 'not an array' })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Missing or invalid "key_results_raw" array')
+    end
+
+    it 'returns 400 if data has only a header row' do
+      post_key_results({ 'key_results_raw' => [raw_sheet_data.first] })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body))
+        .to include('error' => 'Input data must have a header and at least one data row.')
+    end
+
+    it 'returns 200 and a success message for a valid payload' do
+      post_key_results(valid_payload)
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)).to include('message' => 'Key results stored successfully')
+    end
+
+    it 'calls the formatter for each data row' do
+      data_rows = raw_sheet_data.slice(1..-1)
+      expect(Utils::Warehouse::GoogleWorkspace::KeyResultsFormatter).to receive(:new)
+        .exactly(data_rows.count).times.and_return(mocked_formatter_instance)
+      expect(mocked_formatter_instance).to receive(:format).exactly(data_rows.count).times
+
+      post_key_results(valid_payload)
+    end
+
+    it 'calls the storage writer with the correctly formatted payload' do
+      expected_content = [formatted_result, formatted_result] # Since there are two data rows
+      expected_payload = { success: { type: 'key_result', content: expected_content } }
+
+      expect(mocked_storage_writer).to receive(:write).with(expected_payload)
+      post_key_results(valid_payload)
+    end
+
+    it 'returns 500 if the formatter fails' do
+      allow(mocked_formatter_instance).to receive(:format).and_raise(StandardError.new('formatter boom'))
+      post_key_results(valid_payload)
+      expect(last_response.status).to eq(500)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Internal Server Error')
+    end
+  end
+end

--- a/src/use_cases_execution/use_cases_webserver/Google-key-result-script.md
+++ b/src/use_cases_execution/use_cases_webserver/Google-key-result-script.md
@@ -1,0 +1,93 @@
+## Script to Send Key Results from Google Sheets
+
+This script is designed to fetch all raw data from the "OKRs 2025" Google Sheet and send it to a webhook exposed by the backend for processing and storage.
+
+---
+
+## Script
+
+```javascript
+/**
+ * Main function: orchestrates fetching the raw data from the Google Sheet
+ * and sending it to the configured webhook.
+ * This is the function that should be triggered to run automatically.
+ */
+function sendKeyResultsToWebhook() {
+  try {
+    const webhookUrl = PropertiesService.getScriptProperties().getProperty('WEBHOOK_URL');
+    if (!webhookUrl) {
+      console.error('Error: WEBHOOK_URL is not set in Script Properties.');
+      return;
+    }
+
+    const sheetData = fetchSheetData();
+
+    if (!sheetData || sheetData.length <= 1) { // <= 1 to account for header-only sheets
+      console.log('No data found in the sheet to send.');
+      return;
+    }
+
+    console.log(`Sending ${sheetData.length - 1} data rows to webhook...`);
+    const payload = { "key_results_raw": sheetData };
+    const response = postToWebhook(webhookUrl, payload);
+
+    console.log(`Webhook response: Status ${response.getResponseCode()}, Body: ${response.getContentText()}`);
+  } catch (e) {
+    console.error(`Error in sendKeyResultsToWebhook: ${e.toString()}`);
+  }
+}
+
+/**
+ * Fetches all raw data from the Key Results Google Sheet.
+ */
+function fetchSheetData() {
+  const spreadsheetId = PropertiesService.getScriptProperties().getProperty('SPREADSHEET_ID');
+  if (!spreadsheetId) {
+    throw new Error('SPREADSHEET_ID is not set in Script Properties.');
+  }
+
+  try {
+    const sheetName = 'OKRs 2025'; // <-- Make sure this is your exact sheet name
+    const sheet = SpreadsheetApp.openById(spreadsheetId).getSheetByName(sheetName);
+
+    if (!sheet) {
+      throw new Error(`Could not find a sheet named '${sheetName}'.`);
+    }
+
+    // Return all data in the sheet, including the header row.
+    return sheet.getDataRange().getValues();
+  } catch (e) {
+    // Re-throw the error to be caught by the main function
+    throw new Error(`Failed to access or process spreadsheet ${spreadsheetId}. Details: ${e.message}`);
+  }
+}
+
+/**
+ * Sends a JSON payload to a specified URL via a POST request.
+ */
+function postToWebhook(url, payload) {
+  const options = {
+    'method': 'post',
+    'contentType': 'application/json',
+    'payload': JSON.stringify(payload),
+    'muteHttpExceptions': true
+  };
+
+  return UrlFetchApp.fetch(url, options);
+}
+
+```
+
+---
+
+## Environment Variables and Configuration
+
+Set up this variable in the Script Properties section in the Google Apps Script editor.
+
+- **SPREADSHEET_ID**: The unique ID of the Google Sheet containing the Key Results. You can find this in the sheet's URL (the long string between /d/ and /edit).
+
+- **WEBHOOK_URL**: The backend URL that will receive the raw sheet data, including the path (i.e., it should end with /key_results). For local development, you can expose the backend via a tunnel like Ngrok or Cloudflare Tunnels.
+
+---
+
+For instructions on setting up the script, creating time-driven triggers, required permissions, manual testing, notes, and implementing the backend webhook, please refer to [Google-apps-readme.md](./Google-apps-readme.md).

--- a/src/use_cases_execution/use_cases_webserver/app.rb
+++ b/src/use_cases_execution/use_cases_webserver/app.rb
@@ -8,6 +8,7 @@ require_relative '../birthday_next_week/fetch_next_week_birthday_from_google_for
 require_relative '../warehouse/google_workspace/listen_to_google_docs_updates'
 require_relative '../warehouse/google_workspace/listen_to_google_calendar_updates'
 require_relative '../warehouse/google_workspace/listen_to_google_docs_activity_logs'
+require_relative '../warehouse/google_workspace/listen_to_google_key_results_file'
 
 # The WebServer class defines the main Sinatra application responsible for
 # handling incoming webhooks from Google services.
@@ -24,6 +25,7 @@ class WebServer < Sinatra::Base
   use Routes::GoogleDocuments
   use Routes::CalendarEvents
   use Routes::GoogleDocumentsActivityLogs
+  use Routes::KeyResults
 
   get('/') { 'OK' }
 end

--- a/src/use_cases_execution/warehouse/google_workspace/listen_to_google_key_results_file.rb
+++ b/src/use_cases_execution/warehouse/google_workspace/listen_to_google_key_results_file.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'sinatra/base'
+require 'json'
+require 'bas/shared_storage/postgres'
+require 'bas/shared_storage/default'
+require_relative '../config'
+require_relative '../../../utils/warehouse/google_workspace/key_results_format'
+
+module Routes
+  # Routes::KeyResults defines the /key_results endpoint
+  class KeyResults < Sinatra::Base
+    def initialize(args)
+      super(args)
+      write_options = {
+        connection: Config::Database::CONNECTION, db_table: 'warehouse_sync', tag: 'FetchKeyResultsFromWebhook'
+      }
+      @shared_storage_reader = Bas::SharedStorage::Default.new
+      @shared_storage_writer = Bas::SharedStorage::Postgres.new({ write_options: })
+    end
+
+    ##
+    # POST /key_results
+    #
+    # Receives raw Google Sheet data, formats it using a dedicated formatter, and stores it.
+    #
+    post '/key_results' do
+      body = request.body.read.to_s
+      halt 400, { error: 'Empty request body' }.to_json if body.strip.empty?
+      data = JSON.parse(body)
+
+      unless data.is_a?(Hash) && data['key_results_raw'].is_a?(Array)
+        halt 400, { error: 'Missing or invalid "key_results_raw" array' }.to_json
+      end
+
+      raw_data = data['key_results_raw']
+      halt 400, { error: 'Input data must have a header and at least one data row.' }.to_json unless raw_data.length > 1
+
+      data_rows = raw_data.slice(1..-1)
+      formatted_results = data_rows.map do |row|
+        Utils::Warehouse::GoogleWorkspace::KeyResultsFormatter.new(row).format
+      end.compact
+
+      @shared_storage_writer.write(success: { type: 'key_result',
+                                              content: formatted_results })
+
+      status 200
+      { message: 'Key results stored successfully' }.to_json
+    rescue JSON::ParserError => e
+      logger.error "Invalid JSON format: #{e.message}"
+      status 400
+      { error: 'Invalid JSON format' }.to_json
+    rescue StandardError => e
+      logger.error "Failed to process key results data: #{e.message}\n#{e.backtrace.join("\n")}"
+      halt 500, { error: 'Internal Server Error' }.to_json
+    end
+  end
+end

--- a/src/use_cases_execution/warehouse/google_workspace/listen_to_google_key_results_file.rb
+++ b/src/use_cases_execution/warehouse/google_workspace/listen_to_google_key_results_file.rb
@@ -13,10 +13,11 @@ module Routes
     def initialize(args)
       super(args)
       write_options = {
-        connection: Config::Database::CONNECTION, db_table: 'warehouse_sync', tag: 'FetchKeyResultsFromWebhook'
+        connection: Config::Database::CONNECTION,
+        db_table: 'warehouse_sync',
+        tag: 'FetchKeyResultsFromWebhook'
       }
-      @shared_storage_reader = Bas::SharedStorage::Default.new
-      @shared_storage_writer = Bas::SharedStorage::Postgres.new({ write_options: })
+      @shared_storage_writer = Bas::SharedStorage::Postgres.new(write_options: write_options)
     end
 
     ##

--- a/src/use_cases_execution/warehouse/warehouse_ingester.rb
+++ b/src/use_cases_execution/warehouse/warehouse_ingester.rb
@@ -28,6 +28,7 @@ array = PG::TextEncoder::Array.new.encode(
     FetchGoogleDocumentsActivityLogsFromWorkspace
     FetchCalendarEventsFromWebhook
     FetchKpisFromNotionDatabase
+    FetchKeyResultsFromWebhook
   ]
 )
 

--- a/src/utils/warehouse/google_workspace/key_results_format.rb
+++ b/src/utils/warehouse/google_workspace/key_results_format.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require 'securerandom'
+
+module Utils
+  module Warehouse
+    module GoogleWorkspace
+      ##
+      # Class for formatting Key Results data from a Google Sheet row.
+      # It extracts and maps the raw row data into a structured hash.
+      #
+      class KeyResultsFormatter < Base
+        # Main method that returns a hash with formatted key result data.
+        def format
+          {
+            external_key_result_id: SecureRandom.uuid,
+            okr: @data[0],
+            key_result: @data[2],
+            metric: @data[15],
+            current: last_present_value,
+            progress: last_present_value,
+            # progress: last_present_value.to_s.strip == '-' ? 0 : metric_value,
+            period: Time.now.year.to_s,
+            objective: @data[0]
+          }
+        end
+
+        private
+
+        # Finds the last non-empty value in the monthly columns (indices 3 to 14).
+        def last_present_value
+          # @data represents the single row passed during initialization.
+          monthly_values = @data[3..14]
+          last_value = monthly_values.reverse.find { |val| !val.to_s.strip.empty? }
+
+          return 0 if last_value.to_s.strip == '-' || last_value.nil?
+
+          last_value
+        end
+      end
+    end
+  end
+end

--- a/src/utils/warehouse/google_workspace/key_results_format.rb
+++ b/src/utils/warehouse/google_workspace/key_results_format.rb
@@ -12,17 +12,17 @@ module Utils
       #
       class KeyResultsFormatter < Base
         # Main method that returns a hash with formatted key result data.
-        def format
+        def format # rubocop:disable Metrics/MethodLength
           {
-            external_key_result_id: SecureRandom.uuid,
+            external_key_result_id: @data[1],
             okr: @data[0],
             key_result: @data[2],
             metric: @data[15],
             current: last_present_value,
             progress: last_present_value,
-            # progress: last_present_value.to_s.strip == '-' ? 0 : metric_value,
             period: Time.now.year.to_s,
-            objective: @data[0]
+            objective: @data[0],
+            tags: @data[-1]
           }
         end
 


### PR DESCRIPTION
## Description

This pull request introduces the functionality to fetch Key Results from a Google Sheet, replacing the previous Notion-based bot as part of the migration to Google Workspace.

An App Script reads the raw data from the designated Google Sheet and sends it to a new, dedicated backend endpoint. This endpoint then uses a custom formatter to process the raw data into the standard format required by our system and saves it to the shared storage.

Fixes #213 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - POST /key_results endpoint to receive and persist Key Results from Google Sheets with validation and clear error responses.
- Documentation
  - Google Apps Script guide to send data from the "OKRs 2025" sheet to the webhook, plus setup and local dev tips.
- Tests
  - Request specs for invalid/empty payloads, successful ingestion, per-row formatting, storage writes, and error handling.
- Chores
  - Registered the new route and added key-results ingestion to the pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->