### PR TITLE
Implement kpi app script

### DIFF
--- a/spec/use_cases_execution/google_workspace/listen_to_google_kpis_file_spec.rb
+++ b/spec/use_cases_execution/google_workspace/listen_to_google_kpis_file_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bas/shared_storage/postgres'
+require 'bas/shared_storage/default'
+
+require_relative '../../../src/use_cases_execution/warehouse/google_workspace/listen_to_google_kpis_file'
+require_relative '../../../src/utils/warehouse/google_workspace/kpis_format'
+
+RSpec.describe Routes::Kpis do
+  include Rack::Test::Methods
+
+  def app
+    described_class.new({})
+  end
+
+  let(:mocked_storage_writer) { instance_double(Bas::SharedStorage::Postgres, write: nil) }
+  let(:mocked_formatter_instance) { instance_double(Utils::Warehouse::GoogleWorkspace::KpisFormatter) }
+  let(:formatted_result) { { external_kpi_id: 't.testkpi', description: 'Test KPI', name: 'kommit.ops' } }
+
+  let(:raw_sheet_data) do
+    [
+      # Header Row
+      ['Description', 'Name', 'Status', 'Current Value', 'Target Value', 'Percentage', 'external_kpi_id'],
+      # Data Row 1 (with single domain)
+      ['Operational Standardization Index', 'kommit.ops', 'Active', 0.55, 1, 0.55, 't.5941xodai6nr'],
+      # Data Row 2 (with dual domain)
+      ['Example Dual Domain Index', 'kommit, kommit.engineering', 'Active', 0.8, 1, 0.8, 't.dualdomain']
+    ]
+  end
+
+  let(:valid_payload) do
+    { 'key_performance_raw' => raw_sheet_data }
+  end
+
+  def post_kpis(payload)
+    post '/kpis', payload.to_json, { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  context 'POST /kpis' do
+    before do
+      allow(Bas::SharedStorage::Postgres).to receive(:new).and_return(mocked_storage_writer)
+
+      allow(Utils::Warehouse::GoogleWorkspace::KpisFormatter).to receive(:new).and_return(mocked_formatter_instance)
+      allow(mocked_formatter_instance).to receive(:format).and_return(formatted_result)
+
+      allow_any_instance_of(described_class).to receive(:logger).and_return(double('logger').as_null_object)
+    end
+
+    it 'returns 400 for empty request body' do
+      post '/kpis', '', { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Empty request body')
+    end
+
+    it 'returns 400 for invalid JSON' do
+      post '/kpis', '{not valid json}', { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Invalid JSON format')
+    end
+
+    it 'returns 400 for missing key_performance_raw key' do
+      post_kpis({ 'wrong_key' => [] })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Missing or invalid "key_performance_raw" array')
+    end
+
+    it 'returns 400 if key_performance_raw is not an array' do
+      post_kpis({ 'key_performance_raw' => 'not an array' })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Missing or invalid "key_performance_raw" array')
+    end
+
+    it 'returns 400 if data has only a header row' do
+      post_kpis({ 'key_performance_raw' => [raw_sheet_data.first] })
+      expect(last_response.status).to eq(400)
+      expect(JSON.parse(last_response.body))
+        .to include('error' => 'Input data must have a header and at least one data row.')
+    end
+
+    it 'returns 200 and a success message for a valid payload' do
+      post_kpis(valid_payload)
+      expect(last_response.status).to eq(200)
+      expect(JSON.parse(last_response.body)).to include('message' => 'KPIs stored successfully')
+    end
+
+    it 'calls the formatter for each data row' do
+      data_rows = raw_sheet_data.slice(1..-1)
+      expect(Utils::Warehouse::GoogleWorkspace::KpisFormatter).to receive(:new)
+        .exactly(data_rows.count).times.and_return(mocked_formatter_instance)
+      expect(mocked_formatter_instance).to receive(:format).exactly(data_rows.count).times
+
+      post_kpis(valid_payload)
+    end
+
+    it 'calls the storage writer with the correctly formatted payload' do
+      expected_content = [formatted_result, formatted_result] # Since there are two data rows
+      expected_payload = { success: { type: 'kpi', content: expected_content } }
+
+      expect(mocked_storage_writer).to receive(:write).with(expected_payload)
+      post_kpis(valid_payload)
+    end
+
+    it 'returns 500 if the formatter fails' do
+      allow(mocked_formatter_instance).to receive(:format).and_raise(StandardError.new('formatter boom'))
+      post_kpis(valid_payload)
+      expect(last_response.status).to eq(500)
+      expect(JSON.parse(last_response.body)).to include('error' => 'Internal Server Error')
+    end
+  end
+
+  describe Utils::Warehouse::GoogleWorkspace::KpisFormatter do
+    it 'correctly extracts the name from a single-domain value' do
+      data_row = ['Operational Standardization Index', 'kommit.ops', 'Active', 0.55, 1, 0.55, 't.5941xodai6nr']
+      formatter = described_class.new(data_row)
+      expect(formatter.format[:name]).to eq('kommit.ops')
+    end
+
+    it 'correctly extracts the first domain from a dual-domain value' do
+      data_row = ['Example Dual Domain Index', 'kommit, kommit.engineering', 'Active', 0.8, 1, 0.8, 't.dualdomain']
+      formatter = described_class.new(data_row)
+      expect(formatter.format[:name]).to eq('kommit')
+    end
+  end
+end

--- a/src/services/postgres/kpi.rb
+++ b/src/services/postgres/kpi.rb
@@ -15,7 +15,7 @@ module Services
       TABLE = :kpis
 
       RELATIONS = [
-        { service: Domain, external: :external_domain_id, internal: :domain_id }
+        { service: Domain, external: :name, internal: :domain_id }
       ].freeze
 
       def insert(params)

--- a/src/use_cases_execution/use_cases_webserver/Google-kpis-script.md
+++ b/src/use_cases_execution/use_cases_webserver/Google-kpis-script.md
@@ -1,0 +1,133 @@
+## Script to Send KPIs from Google Sheets
+
+This script is designed to fetch all data from the "KPIs Tracking" Google Sheet and send it to a configured webhook on the backend. The data is formatted and sorted before being sent.
+
+---
+
+## Script
+
+```javascript
+/**
+ * Main function: fetches the raw data from the Google Sheet,
+ * enriches it with IDs, formats it, and sends it to the configured webhook.
+ * This is the function that should be triggered to run automatically.
+ */
+function sendKpisToWebhook() {
+  try {
+    const webhookUrl = PropertiesService.getScriptProperties().getProperty('WEBHOOK_URL');
+    if (!webhookUrl) {
+      console.error('Error: WEBHOOK_URL is not set in Script Properties.');
+      return;
+    }
+
+    const sheetDataWithIds = fetchSheetDataWithIds();
+    console.log(sheetDataWithIds);
+
+    if (!sheetDataWithIds || sheetDataWithIds.length <= 1) { // <= 1 to account for header-only sheets
+      console.log('No data found in the sheet to send.');
+      return;
+    }
+
+    console.log(`Sending ${sheetDataWithIds.length - 1} data rows to webhook...`);
+    const payload = { "key_performance_raw": sheetDataWithIds };
+    const response = postToWebhook(webhookUrl, payload);
+
+    console.log(`Webhook response: Status ${response.getResponseCode()}, Body: ${response.getContentText()}`);
+  } catch (e) {
+    console.error(`Error in sendKpisToWebhook: ${e.toString()}`);
+  }
+}
+
+/**
+ * Fetches all raw data from the "KPIs Tracking" Google Sheet, reverses the order
+ * of the rows, and appends a column with the external_kpi_id from a Google Doc.
+ */
+function fetchSheetDataWithIds() {
+  const spreadsheetId = PropertiesService.getScriptProperties().getProperty('SPREADSHEET_ID');
+  const documentId = PropertiesService.getScriptProperties().getProperty('DOCUMENT_ID');
+
+  if (!spreadsheetId || !documentId) {
+    throw new Error('SPREADSHEET_ID or DOCUMENT_ID is not set in Script Properties.');
+  }
+
+  try {
+    const listItemMap = getListItemMapFromDoc(documentId);
+
+    const sheetName = 'KPIs Tracking'; // Make sure this is the exact name of your sheet
+    const sheet = SpreadsheetApp.openById(spreadsheetId).getSheetByName(sheetName);
+
+    if (!sheet) {
+      throw new Error(`Could not find a sheet named '${sheetName}'.`);
+    }
+
+    const values = sheet.getDataRange().getValues();
+    const headers = values[0];
+
+    // Reverse the order of the rows (excluding the header) so they are stored chronologically.
+    const reversedRows = values.slice(1).reverse();
+
+    const newHeaders = [...headers, "external_kpi_id"];
+
+    const rowsWithIds = reversedRows.map(row => {
+      const kpiName = row[0].toString().split(',')[0].trim();
+      const externalId = listItemMap[kpiName] || "";
+      return [...row, externalId];
+    });
+
+    return [newHeaders, ...rowsWithIds];
+  } catch (e) {
+    throw new Error(`Failed to fetch sheet data with IDs. Details: ${e.message}`);
+  }
+}
+
+/**
+ * Reads a Google Doc and creates a map of list items.
+ * The key is the list item's text, and the value is its stable heading ID.
+ */
+function getListItemMapFromDoc(documentId) {
+  const doc = DocumentApp.openById(documentId);
+  const tabs = doc.getTabs();
+  const listItemMap = {};
+
+  console.log(`Found ${tabs.length} tab(s) to process.`);
+
+  tabs.forEach(function(tab) {
+    const tabId = tab.getId();
+    const name = tab.getTitle().trim();
+    listItemMap[name] = tabId;
+  });
+
+  return listItemMap;
+}
+
+/**
+ * Sends a JSON payload to a specified URL via a POST request.
+ */
+function postToWebhook(url, payload) {
+  const options = {
+    'method': 'post',
+    'contentType': 'application/json',
+    'payload': JSON.stringify(payload),
+    'muteHttpExceptions': true
+  };
+
+  return UrlFetchApp.fetch(url, options);
+}
+
+```
+
+---
+
+## Environment Variables and Configuration
+
+Set up this variable in the Script Properties section in the Google Apps Script editor.
+
+- **SPREADSHEET_ID**: The unique ID of the Google Sheet containing the KPIs. You can find this in the sheet's URL (the long string between /d/ and /edit).
+
+- **DOCUMENT_ID**: The unique ID of the Google Doc that contains the KPI IDs. This ID is also found in the document's URL.
+
+- **WEBHOOK_URL**: The backend URL that will receive the raw sheet data, including the path (i.e., it should end with /kpis). For local development, you can expose the backend via a tunnel like Ngrok or Cloudflare Tunnels.
+
+---
+
+For instructions on setting up the script, creating time-driven triggers, required permissions, manual testing, notes, and implementing the backend webhook, please refer to [Google-apps-readme.md](./Google-apps-readme.md).

--- a/src/use_cases_execution/use_cases_webserver/app.rb
+++ b/src/use_cases_execution/use_cases_webserver/app.rb
@@ -9,6 +9,7 @@ require_relative '../warehouse/google_workspace/listen_to_google_docs_updates'
 require_relative '../warehouse/google_workspace/listen_to_google_calendar_updates'
 require_relative '../warehouse/google_workspace/listen_to_google_docs_activity_logs'
 require_relative '../warehouse/google_workspace/listen_to_google_key_results_file'
+require_relative '../warehouse/google_workspace/listen_to_google_kpis_file'
 
 # The WebServer class defines the main Sinatra application responsible for
 # handling incoming webhooks from Google services.
@@ -26,6 +27,7 @@ class WebServer < Sinatra::Base
   use Routes::CalendarEvents
   use Routes::GoogleDocumentsActivityLogs
   use Routes::KeyResults
+  use Routes::Kpis
 
   get('/') { 'OK' }
 end

--- a/src/use_cases_execution/warehouse/google_workspace/listen_to_google_kpis_file.rb
+++ b/src/use_cases_execution/warehouse/google_workspace/listen_to_google_kpis_file.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'sinatra/base'
+require 'json'
+require 'bas/shared_storage/postgres'
+require 'bas/shared_storage/default'
+require_relative '../config'
+require_relative '../../../utils/warehouse/google_workspace/kpis_format'
+
+module Routes
+  # Routes::Kpis defines the /kpis endpoint
+  class Kpis < Sinatra::Base
+    def initialize(args)
+      super(args)
+      write_options = {
+        connection: Config::Database::CONNECTION,
+        db_table: 'warehouse_sync',
+        tag: 'FetchKpisFromWebhook'
+      }
+      @shared_storage_writer = Bas::SharedStorage::Postgres.new(write_options: write_options)
+    end
+
+    ##
+    # POST /kpis
+    #
+    # Receives raw Google Sheet data, formats it using a dedicated formatter, and stores it.
+    #
+    post '/kpis' do
+      body = request.body.read.to_s
+      halt 400, { error: 'Empty request body' }.to_json if body.strip.empty?
+      data = JSON.parse(body)
+
+      unless data.is_a?(Hash) && data['key_performance_raw'].is_a?(Array)
+        halt 400, { error: 'Missing or invalid "key_performance_raw" array' }.to_json
+      end
+
+      raw_data = data['key_performance_raw']
+      halt 400, { error: 'Input data must have a header and at least one data row.' }.to_json unless raw_data.length > 1
+
+      data_rows = raw_data.slice(1..-1)
+
+      ordered_data_rows = order_by_month(data_rows)
+
+      formatted_kpis = ordered_data_rows.map do |row|
+        Utils::Warehouse::GoogleWorkspace::KpisFormatter.new(row).format
+      end.compact
+
+      @shared_storage_writer.write(success: { type: 'kpi',
+                                              content: formatted_kpis })
+
+      status 200
+      { message: 'KPIs stored successfully' }.to_json
+    rescue JSON::ParserError => e
+      logger.error "Invalid JSON format: #{e.message}"
+      status 400
+      { error: 'Invalid JSON format' }.to_json
+    rescue StandardError => e
+      logger.error "Failed to process KPIs data: #{e.message}\n#{e.backtrace.join("\n")}"
+      halt 500, { error: 'Internal Server Error' }.to_json
+    end
+
+    private
+
+    ##
+    # Orders rows by the month column (index 5 = 6th column).
+    #
+    def order_by_month(rows)
+      month_order = %w[January February March April May June July August September October November December]
+      rows.sort_by do |row|
+        month = row[5].to_s.strip
+        month_order.index(month) || 99
+      end
+    end
+  end
+end

--- a/src/use_cases_execution/warehouse/warehouse_ingester.rb
+++ b/src/use_cases_execution/warehouse/warehouse_ingester.rb
@@ -29,6 +29,7 @@ array = PG::TextEncoder::Array.new.encode(
     FetchCalendarEventsFromWebhook
     FetchKpisFromNotionDatabase
     FetchKeyResultsFromWebhook
+    FetchKpisFromWebhook
   ]
 )
 

--- a/src/utils/warehouse/google_workspace/kpis_format.rb
+++ b/src/utils/warehouse/google_workspace/kpis_format.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require 'securerandom'
+
+module Utils
+  module Warehouse
+    module GoogleWorkspace
+      ##
+      # Class for formatting KPIs data from a Google Sheet row.
+      # It extracts and maps the raw row data into a structured hash.
+      #
+      class KpisFormatter < Base
+        # Main method that returns a hash with formatted KPI data.
+        def format
+          {
+            external_kpi_id: @data[-1],
+            description: @data[0],
+            status: @data[-2],
+            current_value: @data[3],
+            target_value: @data[4],
+            percentage: @data[5],
+            name: @data[1].to_s.split(',').first.strip # domain name
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR introduces a new process that fetches data from a dedicated Google Sheet and sends it to a new backend endpoint for processing and storage.

The changes include:
- A Google Apps Script that retrieves data from the "KPIs Tracking" sheet, reverses the order of the rows for chronological storage, and appends an `external_kpi_id` by matching the KPI description from a separate Google Doc. It also handles multi-domain values by taking only the first domain.
- A new `/kpis` endpoint in the backend to receive the payload from the Apps Script.
- A new `KpisFormatter` utility class to correctly format the incoming data.
- Documentation for setting up the Apps Script with the required environment variables.
- A comprehensive RSpec test suite to ensure the new endpoint and formatter are working as expected.

Fixes #217

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
