### PR TITLE
Prepare release v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.12.1. (18.09.25)
+- [Quote all Grafana loki parameters](https://github.com/kommitters/bas_use_cases/pull/230)
+- [Send logs to grafana](https://github.com/kommitters/bas_use_cases/pull/229)
+- [Format worklogs tags](https://github.com/kommitters/bas_use_cases/pull/228)
+- [Implement APEX Fetch Bot for Data Warehouse Ingestion](https://github.com/kommitters/bas_use_cases/pull/226)
+
 ## 1.12.0 (05.09.25)
 - [Fix library import problem in kpi postgres service](https://github.com/kommitters/bas_use_cases/pull/210)
 - [Resolve data saving issue in Warehouse Ingester](https://github.com/kommitters/bas_use_cases/pull/212)


### PR DESCRIPTION
Prepare release v1.12.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for version 1.12.1 (2025-09-18).
  * Documented updates: quoted Grafana Loki parameters, enabled log forwarding to Grafana, improved worklog tag formatting, and noted the APEX Fetch Bot for data warehouse ingestion.
  * No functional changes to the application; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->