### PR TITLE
Fix Operaton API request to use instance variables for base URL and auth

### DIFF
--- a/src/utils/warehouse/operaton/request.rb
+++ b/src/utils/warehouse/operaton/request.rb
@@ -10,26 +10,39 @@ module Utils
     # Encapsulates API calls to the Operaton service.
     class Request
       include HTTParty
-      @base_url = "#{Config::Operaton::BASE_URI}/engine-rest"
-      @basic_auth = {
-        username: Config::Operaton::USER_ID,
-        password: Config::Operaton::PASSWORD_SECRET
-      }
-
-      def self.execute(endpoint:, method: :get, query_params: {}, body: {})
-        url = "#{@base_url}/#{endpoint}"
-        options = build_request_options(method: method, query: query_params, body: body)
-        HTTParty.public_send(method, url, options)
-      end
-
       class << self
+        def execute(endpoint:, method: :get, query_params: {}, body: {})
+          url = "#{base_url}/#{endpoint}"
+          options = build_request_options(method: method, query: query_params, body: body)
+          HTTParty.public_send(method, url, options)
+        end
+
+        def base_url
+          @base_url ||= begin
+            base_uri = Config::Operaton::BASE_URI
+            raise 'Operaton BASE_URI not configured' if base_uri.nil? || base_uri.empty?
+
+            "#{base_uri}/engine-rest"
+          end
+        end
+
+        def basic_auth
+          @basic_auth ||= begin
+            user_id = Config::Operaton::USER_ID
+            password = Config::Operaton::PASSWORD_SECRET
+            raise 'Operaton credentials not configured' if user_id.nil? || password.nil?
+
+            { username: user_id, password: password }
+          end
+        end
+
         private
 
         def build_request_options(method:, query:, body:)
           options = {
             query: query,
             timeout: 20,
-            basic_auth: @basic_auth
+            basic_auth: basic_auth
           }
 
           if %i[post put patch].include?(method)


### PR DESCRIPTION
## Description

Fixes #238

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized request handling and credential management for warehouse operations.
  * Ensures request bodies for create/update actions are sent as JSON with correct headers.
  * Preserves existing timeout behavior while attaching credentials to requests.
  * Adds validation and clearer errors when required service URL or credentials are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->