### PR TITLE
Temporarily disable Operaton bots and increase ingester frequency

### DIFF
--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -154,13 +154,13 @@ module UseCasesExecution
       { path: "#{__dir__}/warehouse/apex/fetch_tasks.rb", time: ['06:00'] },
       { path: "#{__dir__}/warehouse/apex/fetch_weekly_scopes.rb", time: ['06:05'] },
       { path: "#{__dir__}/warehouse/apex/fetch_weekly_scopes_tasks.rb", time: ['06:10'] },
-      { path: "#{__dir__}/warehouse/warehouse_ingester.rb", interval: 3_600_000 }
+      { path: "#{__dir__}/warehouse/warehouse_ingester.rb", interval: 300_000 }
     ].freeze
 
-    OPERATON_WAREHOUSE_SYNC_SCHEDULES = [
-      { path: "#{__dir__}/warehouse/operaton/fetch_processes.rb", interval: 3_600_000 },
-      { path: "#{__dir__}/warehouse/operaton/fetch_activities.rb", interval: 3_600_000 },
-      { path: "#{__dir__}/warehouse/operaton/fetch_incidents.rb", interval: 3_600_000 }
-    ].freeze
+    # OPERATON_WAREHOUSE_SYNC_SCHEDULES = [
+    #   { path: "#{__dir__}/warehouse/operaton/fetch_processes.rb", interval: 3_600_000 },
+    #   { path: "#{__dir__}/warehouse/operaton/fetch_activities.rb", interval: 3_600_000 },
+    #   { path: "#{__dir__}/warehouse/operaton/fetch_incidents.rb", interval: 3_600_000 }
+    # ].freeze
   end
 end

--- a/src/use_cases_execution/warehouse/warehouse_ingester.rb
+++ b/src/use_cases_execution/warehouse/warehouse_ingester.rb
@@ -35,9 +35,6 @@ array = PG::TextEncoder::Array.new.encode(
     FetchPersonsFromApex
     FetchProjectsFromApex
     FetchWorkItemsFromApex
-    FetchProcessesFromOperaton
-    FetchActivitiesFromOperaton
-    FetchIncidentsFromOperaton
     FetchOkrsFromApex
     FetchKrsFromApex
     FetchMilestonesFromApex


### PR DESCRIPTION
## Description

This PR implements a temporary fix to stabilize the warehouse pipeline, which is currently backlogged due to the Operaton bots fetching an excessive volume of data. This backlog is preventing other bots (like APEX) from processing data in a timely manner.

To address this, this PR:

- Disables all Operaton bots (e.g., FetchActivitiesFromOperaton) from the cron schedule.
- Increases the warehouse_ingester execution interval to run every 5 minutes.

This will allow the ingester to clear the current backlog and process data from other sources more frequently.

Fixes #247


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced warehouse data synchronization frequency to ensure fresher, more timely data availability.
  * Refined warehouse data ingestion by adjusting which external data sources are included in the synchronization pipeline.
  * Streamlined operations by optimizing synchronization schedule configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->