### PR TITLE
Adjust DO billing pipeline to always read latest records

### DIFF
--- a/src/use_cases_execution/digital_ocean_bill_alert/fetch_billing_from_digital_ocean.rb
+++ b/src/use_cases_execution/digital_ocean_bill_alert/fetch_billing_from_digital_ocean.rb
@@ -12,8 +12,8 @@ read_options = {
   db_table: 'do_billing',
   tag: 'FetchBillingFromDigitalOcean',
   avoid_process: true,
-  where: 'archived=$1 AND tag=$2 ORDER BY inserted_at DESC',
-  params: [false, 'FetchBillingFromDigitalOcean']
+  where: 'tag=$1 ORDER BY archived ASC, inserted_at DESC',
+  params: ['FetchBillingFromDigitalOcean']
 }
 
 write_options = {

--- a/src/use_cases_execution/digital_ocean_bill_alert/format_do_bill_alert.rb
+++ b/src/use_cases_execution/digital_ocean_bill_alert/format_do_bill_alert.rb
@@ -10,7 +10,9 @@ require_relative 'config'
 read_options = {
   connection: Config::CONNECTION,
   db_table: 'do_billing',
-  tag: 'FetchBillingFromDigitalOcean'
+  tag: 'FetchBillingFromDigitalOcean',
+  where: 'tag=$1 ORDER BY archived ASC, inserted_at DESC',
+  params: ['FetchBillingFromDigitalOcean']
 }
 
 write_options = {

--- a/src/use_cases_execution/digital_ocean_bill_alert/notify_do_bill_alert_workspace.rb
+++ b/src/use_cases_execution/digital_ocean_bill_alert/notify_do_bill_alert_workspace.rb
@@ -10,7 +10,9 @@ require_relative 'config'
 read_options = {
   connection: Config::CONNECTION,
   db_table: 'do_billing',
-  tag: 'FormatDoBillAlert'
+  tag: 'FormatDoBillAlert',
+  where: 'tag=$1 ORDER BY archived ASC, inserted_at DESC',
+  params: ['FormatDoBillAlert']
 }
 
 write_options = {


### PR DESCRIPTION
## Description

Update the read_options for every step in the DigitalOcean billing pipeline (fetch_billing_from_digital_ocean.rb, format_do_bill_alert.rb, notify_do_bill_alert_workspace.rb) so the queries order by archived ASC, inserted_at DESC.
This ensures the bots always read the most recent record for a given tag, even if it was already marked as processed or archived by the garbage collector.
No new dependencies and no issue linked.

Fixes # (issue)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined how Digital Ocean billing records are filtered and ordered during alert processing to ensure accurate, consistent billing notifications. Enhanced data retrieval logic across the billing alert system to correctly handle record archival status and timing.

* **Refactor**
  * Optimized query patterns in the billing alert infrastructure for improved maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->