### PR TITLE
Update ambiguous message to "No data found"

### DIFF
--- a/spec/implementations/warehouse/warehouse_ingester_spec.rb
+++ b/spec/implementations/warehouse/warehouse_ingester_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Implementation::WarehouseIngester do
           expect(service).not_to have_received(:query)
 
           expect(BAS_LOGGER).to have_received(:info).with(hash_including(
-                                                            message: 'Ingestion skipped: unprocessable response.'
+                                                            message: 'Ingestion skipped: No data found.'
                                                           )).once
         end
       end

--- a/src/implementations/warehouse_ingester.rb
+++ b/src/implementations/warehouse_ingester.rb
@@ -130,7 +130,7 @@ module Implementation
     #
     def ingestion_ready?
       if unprocessable_response
-        log_ingestion_event(:info, 'Ingestion skipped: unprocessable response.', processed: 0)
+        log_ingestion_event(:info, 'Ingestion skipped: No data found.', processed: 0)
         return false
       end
 


### PR DESCRIPTION
## Description

This PR updates an ambiguous log message in the Warehouse Ingester.

The original message, Ingestion skipped: unprocessable response., was triggered for multiple conditions (a null response, an empty response, or fields with null/empty values), which made it difficult to debug.

This change replaces it with the clearer message Ingestion skipped: No data found. to improve the quality and clarity of our logs, as requested in the issue.

Fixes #256

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ingestion status message for improved clarity when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->