### PR TITLE
Change variable to use raw value on interval for GitHub schedules.

### DIFF
--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -9,17 +9,6 @@ module UseCasesExecution
   # time: The time when the script will be executed
   # day: The day when the script will be executed
   module Schedules
-    FIVE_MIN = 300_000
-    TEN_MIN = 600_000
-    FIFTEEN_MIN = 900_000
-    TWENTY_MIN = 1_200_000
-    TWENTY_FIVE_MIN = 1_500_000
-    THIRTY_MIN = 1_800_000
-    TWO_HOURS = 7_200_000
-
-    KOMMIT_CO_BASE  = 0
-    KOMMITTERS_BASE = 1_200_000
-
     def self.load
       constants.map { |const| const_get(const) }.flatten
     end
@@ -162,15 +151,17 @@ module UseCasesExecution
       { path: "#{__dir__}/warehouse/apex/fetch_weekly_scopes_tasks.rb", time: ['06:10'] },
       { path: "#{__dir__}/warehouse/apex/fetch_people.rb", time: ['06:15'] },
 
-      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_repositories.rb", interval: TWO_HOURS },
-      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_issues.rb", interval: FIVE_MIN },
-      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_releases.rb", interval: TEN_MIN },
-      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_pull_requests.rb", interval: FIFTEEN_MIN },
+      # GitHub Kommit-Co Schedules
+      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_repositories.rb", interval: 7_200_000 },
+      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_issues.rb", interval: 300_000 },
+      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_releases.rb", interval: 600_000 },
+      { path: "#{__dir__}/warehouse/github/kommit_co/fetch_pull_requests.rb", interval: 900_000 },
 
-      { path: "#{__dir__}/warehouse/github/kommitters/fetch_repositories.rb", interval: TWO_HOURS },
-      { path: "#{__dir__}/warehouse/github/kommitters/fetch_issues.rb", interval: TWENTY_MIN },
-      { path: "#{__dir__}/warehouse/github/kommitters/fetch_releases.rb", interval: TWENTY_FIVE_MIN },
-      { path: "#{__dir__}/warehouse/github/kommitters/fetch_pull_requests.rb", interval: THIRTY_MIN },
+      # GitHub Kommitters Schedules
+      { path: "#{__dir__}/warehouse/github/kommitters/fetch_repositories.rb", interval: 7_200_000 },
+      { path: "#{__dir__}/warehouse/github/kommitters/fetch_issues.rb", interval: 1_200_000 },
+      { path: "#{__dir__}/warehouse/github/kommitters/fetch_releases.rb", interval: 1_500_000 },
+      { path: "#{__dir__}/warehouse/github/kommitters/fetch_pull_requests.rb", interval: 1_800_000 },
 
       { path: "#{__dir__}/warehouse/warehouse_ingester.rb", interval: 1_800_000 } # 30 minutes
     ].freeze


### PR DESCRIPTION
## Description

This PR fixes a runtime error in the `cronjobs orchestrator` caused by introducing non-schedule constants (interval helpers) into the Schedules module.

The `Schedules.load` method dynamically loads all module constants and assumes they are arrays of schedule hashes. Adding numeric constants (e.g. interval helpers) caused the loader to include integers in the execution list, which later resulted in the runtime error:

- `no implicit conversion of Symbol into Integer.`


Fixes #279 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Schedule configurations have been restructured to improve code maintainability. Interval timings remain consistent with previous behavior, ensuring no impact on application functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->