### PR TITLE
Simplify staging deploy by using a single Docker image and removing build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,11 @@ jobs:
             docker rm -f warehouse_webserver warehouse_cronjobs 2>/dev/null || true
             docker rm -f app_bas_webserver app_bas_cronjobs 2>/dev/null || true
 
-            docker compose -p bas down --remove-orphans || true
-            docker compose -p warehouse down --remove-orphans || true
+            docker compose -p bas down --remove-orphans --timeout 10 || true
+            docker compose -p warehouse down --remove-orphans --timeout 10 || true
 
-            docker compose -p bas up -d --build bas_cronjobs bas_webserver
+            docker compose -p bas build --progress=plain
+
+            docker compose -p bas up -d bas_cronjobs bas_webserver
 
             rm -f /root/releases/bas_scripts.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-# Use the official Ruby image from the Docker Hub
 FROM ruby:3.3.3-bullseye
 
-# Install necessary dependencies
 RUN apt-get update && apt-get install -y \
     cron \
     build-essential \
@@ -12,26 +10,29 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Sinatra
 RUN gem install sinatra rackup puma
 
-# Add PostgreSQL apt repository
 RUN install -d /usr/share/postgresql-common/pgdg && \
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail \
     https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
     sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
-# Install PostgreSQL client
 RUN apt-get update && apt-get install -y postgresql-client-16 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Set up the working directory for the application
 WORKDIR /app
 
-# Copy the project files
-COPY . .
+# Match lockfile bundler version to avoid auto-install each build
+RUN gem install bundler -v 2.6.8
 
-# Install Ruby gems
+# Bundler config for consistent gem path (helps caching/stability)
+RUN bundle config set path '/usr/local/bundle'
+
+# Copy only gemfiles first so bundle install is cacheable
+COPY Gemfile Gemfile.lock ./
+
 RUN bundle install
 
+# Copy the rest of the project
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
       device: .
 
 x-common: &default-build
+  image: bas_app:latest
   build:
     context: .
 
@@ -37,7 +38,7 @@ services:
   bas_webserver:
     container_name: bas_webserver
     ports:
-      - 4567:4567
+      - "4567:4567"
     restart: always
     <<: *default-build
     volumes:


### PR DESCRIPTION
## Description

This pull request updates the staging deployment strategy to use a single pre-built Docker image shared by both containers. The deployment flow is simplified by removing the `--build` flag from container startup, ensuring that all services run from the same immutable image.

This change improves deployment consistency, reduces staging deploy times, and prevents unintended differences between containers caused by rebuilding images during deployment.

No application logic is modified; this change is strictly related to infrastructure and deployment behavior.

Fixes Issue #284 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined deployment workflow with enhanced timeout handling and explicit build sequence
  * Optimized Docker build configuration with improved caching and dependency management
  * Updated Docker Compose service configuration for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->