### PR TITLE
deprecate: remove pto and birthday from schedules and webserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,26 +34,3 @@ services:
         loki-timeout: "10s"
         keep-file: "true"
         mode: "non-blocking"
-
-  bas_webserver:
-    container_name: bas_webserver
-    ports:
-      - "4567:4567"
-    restart: always
-    <<: *default-build
-    volumes:
-      - cronjobs:/app
-    command: ["bash", "/app/scripts/update_web_container.sh"]
-    deploy:
-      resources:
-        limits:
-          memory: 100M
-    logging:
-      driver: loki
-      options:
-        loki-url: "${GRAFANA_LOKI_FULL_URL}"
-        loki-retries: "10"
-        loki-max-backoff: "8s"
-        loki-timeout: "10s"
-        keep-file: "true"
-        mode: "non-blocking"

--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -25,12 +25,12 @@ module UseCasesExecution
     #   { path: "#{__dir__}/birthday_next_week/garbage_collector.rb", time: ['00:00'] }
     # ].freeze
 
-    DIGITAL_OCEAN_BILL_ALERT_SCHEDULES = [
-      { path: "#{__dir__}/digital_ocean_bill_alert/fetch_billing_from_digital_ocean.rb", interval: 10_000 },
-      { path: "#{__dir__}/digital_ocean_bill_alert/format_do_bill_alert.rb", interval: 10_000 },
-      { path: "#{__dir__}/digital_ocean_bill_alert/notify_do_bill_alert_workspace.rb", interval: 10_000 },
-      { path: "#{__dir__}/digital_ocean_bill_alert/garbage_collector.rb", time: ['00:00'] }
-    ].freeze
+    # DIGITAL_OCEAN_BILL_ALERT_SCHEDULES = [
+    #   { path: "#{__dir__}/digital_ocean_bill_alert/fetch_billing_from_digital_ocean.rb", interval: 10_000 },
+    #   { path: "#{__dir__}/digital_ocean_bill_alert/format_do_bill_alert.rb", interval: 10_000 },
+    #   { path: "#{__dir__}/digital_ocean_bill_alert/notify_do_bill_alert_workspace.rb", interval: 10_000 },
+    #   { path: "#{__dir__}/digital_ocean_bill_alert/garbage_collector.rb", time: ['00:00'] }
+    # ].freeze
 
     # PTO_SCHEDULES = [
     #   { path: "#{__dir__}/pto/fetch_pto_from_apex.rb", time: ['13:20'] },

--- a/src/use_cases_execution/schedules.rb
+++ b/src/use_cases_execution/schedules.rb
@@ -13,17 +13,17 @@ module UseCasesExecution
       constants.map { |const| const_get(const) }.flatten
     end
 
-    BIRTHDAY_SCHEDULES = [
-      { path: "#{__dir__}/birthday/format_birthday_workspace.rb", time: ['12:55'] },
-      { path: "#{__dir__}/birthday/notify_birthday_in_workspace.rb", time: ['13:05'] },
-      { path: "#{__dir__}/birthday/garbage_collector.rb", time: ['00:00'] }
-    ].freeze
+    # BIRTHDAY_SCHEDULES = [
+    #   { path: "#{__dir__}/birthday/format_birthday_workspace.rb", time: ['12:55'] },
+    #   { path: "#{__dir__}/birthday/notify_birthday_in_workspace.rb", time: ['13:05'] },
+    #   { path: "#{__dir__}/birthday/garbage_collector.rb", time: ['00:00'] }
+    # ].freeze
 
-    BIRTHDAY_NEXT_WEEK_SCHEDULES = [
-      { path: "#{__dir__}/birthday_next_week/format_next_week_birthday_workspace.rb", time: ['12:55'] },
-      { path: "#{__dir__}/birthday_next_week/notify_next_week_birthday_in_workspace.rb", time: ['13:05'] },
-      { path: "#{__dir__}/birthday_next_week/garbage_collector.rb", time: ['00:00'] }
-    ].freeze
+    # BIRTHDAY_NEXT_WEEK_SCHEDULES = [
+    #   { path: "#{__dir__}/birthday_next_week/format_next_week_birthday_workspace.rb", time: ['12:55'] },
+    #   { path: "#{__dir__}/birthday_next_week/notify_next_week_birthday_in_workspace.rb", time: ['13:05'] },
+    #   { path: "#{__dir__}/birthday_next_week/garbage_collector.rb", time: ['00:00'] }
+    # ].freeze
 
     DIGITAL_OCEAN_BILL_ALERT_SCHEDULES = [
       { path: "#{__dir__}/digital_ocean_bill_alert/fetch_billing_from_digital_ocean.rb", interval: 10_000 },
@@ -32,18 +32,18 @@ module UseCasesExecution
       { path: "#{__dir__}/digital_ocean_bill_alert/garbage_collector.rb", time: ['00:00'] }
     ].freeze
 
-    PTO_SCHEDULES = [
-      { path: "#{__dir__}/pto/fetch_pto_from_apex.rb", time: ['13:20'] },
-      { path: "#{__dir__}/pto/humanize_pto_workspace.rb", time: ['13:25'] },
-      { path: "#{__dir__}/pto/notify_pto_in_workspace.rb", time: ['13:35'] },
-      { path: "#{__dir__}/pto/garbage_collector.rb", time: ['00:00'] }
-    ].freeze
+    # PTO_SCHEDULES = [
+    #   { path: "#{__dir__}/pto/fetch_pto_from_apex.rb", time: ['13:20'] },
+    #   { path: "#{__dir__}/pto/humanize_pto_workspace.rb", time: ['13:25'] },
+    #   { path: "#{__dir__}/pto/notify_pto_in_workspace.rb", time: ['13:35'] },
+    #   { path: "#{__dir__}/pto/garbage_collector.rb", time: ['00:00'] }
+    # ].freeze
 
-    PTO_NEXT_WEEK_SCHEDULES = [
-      { path: "#{__dir__}/pto_next_week/humanize_next_week_pto_workspace.rb", time: ['12:55'], day: ['Thursday'] },
-      { path: "#{__dir__}/pto_next_week/notify_pto_next_week_in_workspace.rb", time: ['13:05'], day: ['Thursday'] },
-      { path: "#{__dir__}/pto_next_week/garbage_collector.rb", time: ['23:00'], day: ['Thursday'] }
-    ].freeze
+    # PTO_NEXT_WEEK_SCHEDULES = [
+    #   { path: "#{__dir__}/pto_next_week/humanize_next_week_pto_workspace.rb", time: ['12:55'], day: ['Thursday'] },
+    #   { path: "#{__dir__}/pto_next_week/notify_pto_next_week_in_workspace.rb", time: ['13:05'], day: ['Thursday'] },
+    #   { path: "#{__dir__}/pto_next_week/garbage_collector.rb", time: ['23:00'], day: ['Thursday'] }
+    # ].freeze
 
     SUPPORT_EMAIL_SCHEDULES = [
       { path: "#{__dir__}/support_email/fetch_emails_from_imap.rb", time: ['12:40', '14:40', '18:40', '20:40'] },

--- a/src/use_cases_execution/use_cases_webserver/app.rb
+++ b/src/use_cases_execution/use_cases_webserver/app.rb
@@ -12,8 +12,8 @@ require_relative '../birthday_next_week/fetch_next_week_birthday_from_google_for
 # for all available endpoints.
 # WebServer is the main Sinatra application class.
 class WebServer < Sinatra::Base
-  use Routes::Birthdays
-  use Routes::NextWeekBirthdays
+  # use Routes::Birthdays
+  # use Routes::NextWeekBirthdays
 
   get('/') { 'OK' }
 end


### PR DESCRIPTION
## Description

This change deprecates PTO and Birthday use cases (including their “next week” versions). Scheduled executions and associated web server routes have been disabled. In addition, the web server service was removed from the container orchestration file, as its main function was to receive these webhooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled several scheduling features (birthdays, PTO, next-week alerts, digital-ocean bill alerts and related schedules), reducing active scheduled tasks.
  * Disabled the associated birthday endpoints.
  * Removed the webserver service from the deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->